### PR TITLE
Clean up config constants and farm tips

### DIFF
--- a/config.js
+++ b/config.js
@@ -122,31 +122,8 @@ const GAME_CONFIG = {
     }
 };
 
-// Rhythm game speeds by type (milliseconds between notes)
-const RHYTHM_SPEEDS = {
-    pitch: 1500,
-    rapid: 800,
-    smooth: 2000,
-    battle: 1000,
-    slow: 2500,
-    rock: 1200,
-    cosmic: 1800,
-    pop: 1100,
-    electronic: 900
-};
-
-// Game instructions for each rhythm type
-const RHYTHM_INSTRUCTIONS = {
-    pitch: "Tap when notes cross the center! Match the diva's perfect pitch!",
-    rapid: "Rapid TAP to rev the engine! Don't let it stall!",
-    smooth: "Gentle taps for a smooth serenade!",
-    battle: "TAP to parry grass attacks! Defend the pasture!",
-    slow: "Slow, deliberate taps for melancholy mood!",
-    rock: "Rock out with the rhythm! Feel the groove!",
-    cosmic: "TAP in cosmic harmony with the universe!",
-    pop: "Hit those pop beats with perfect timing!",
-    electronic: "Drop the bass with electronic beats!"
-};
+// Speeds and instructions were previously defined here but now come from
+// rhythm-patterns.json, so these constants have been removed.
 
 // Farm tips that appear in the bulletin
 const FARM_TIPS = [
@@ -168,5 +145,5 @@ const FARM_TIPS = [
 
 // Export config for use in other files
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { GAME_CONFIG, RHYTHM_SPEEDS, RHYTHM_INSTRUCTIONS, FARM_TIPS };
+    module.exports = { GAME_CONFIG, FARM_TIPS };
 }

--- a/scripts.js
+++ b/scripts.js
@@ -781,22 +781,7 @@ function updateBulletin() {
 }
 
 function getFarmTip() {
-    const tips = [
-        "Plant rainbow crops for maximum profit!",
-        "Keep all your cows happy for bonus rewards!",
-        "Upgrades make rhythm games easier to win!",
-        "Perfect scores unlock secret cows!",
-        "Harvest crops regularly to keep earning!",
-        "Each cow has their own rhythm style!",
-        "The neon pink barn doubles milk production!",
-        "Golden cowbell makes cows start happier each day!",
-        "Build combos in rhythm games for bonus points!",
-        "Secret cows have special unlock conditions!",
-        "Achievements give permanent bonuses!",
-        "Try different crops to unlock new achievements!",
-        "Play at midnight for a special achievement!"
-    ];
-    return tips[Math.floor(Math.random() * tips.length)];
+    return FARM_TIPS[Math.floor(Math.random() * FARM_TIPS.length)];
 }
 
 // FIXED: Combined unlock check function that handles both regular and secret cows


### PR DESCRIPTION
## Summary
- drop duplicate rhythm speed/instruction constants from `config.js`
- use global `FARM_TIPS` list in `getFarmTip`

## Testing
- `node --check scripts.js`
- `node --check config.js`


------
https://chatgpt.com/codex/tasks/task_e_68605feb8060833195ce6b0c49c0da24