### PR TITLE
Remove obsolete hold control

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,6 @@
     </div>
     <div class="mobile-controls">
       <button class="control-btn" id="tapBtn">&#x1F446;<br>TAP</button>
-      <button class="control-btn" id="holdBtn">&#x270A;<br>HOLD</button>
     </div>
     <button class="close-minigame" onclick="closeMinigame()">&#x274C; CLOSE</button>
   </div>

--- a/scripts.js
+++ b/scripts.js
@@ -1702,7 +1702,6 @@ loadGameData().then(() => {
 // Mobile touch controls for minigame - using DOMContentLoaded to avoid timing issues
 document.addEventListener('DOMContentLoaded', function() {
     const tapBtn = document.getElementById('tapBtn');
-    const holdBtn = document.getElementById('holdBtn');
     
     if (tapBtn) {
         tapBtn.addEventListener('touchstart', (e) => {
@@ -1735,29 +1734,7 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
     
-    if (holdBtn) {
-        holdBtn.addEventListener('touchstart', (e) => {
-            e.preventDefault();
-            if (currentMinigame.gameActive) {
-                const notes = document.querySelectorAll('.rhythm-note');
-                if (notes.length > 0) {
-                    const marker = document.querySelector('.rhythm-marker');
-                    if (!marker) return;
-                    
-                    const markerRect = marker.getBoundingClientRect();
-                    
-                    notes.forEach(note => {
-                        const noteRect = note.getBoundingClientRect();
-                        const distance = Math.abs(noteRect.left + noteRect.width/2 - markerRect.left - markerRect.width/2);
-                        
-                        if (distance < 120) {
-                            hitNote(note);
-                        }
-                    });
-                }
-            }
-        });
-    }
+    
 });
 
 // Auto-update crop timers


### PR DESCRIPTION
## Summary
- remove HOLD button from minigame UI
- strip hold button touch logic from scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860603661908331b550e65dac12a338