### PR TITLE
Fix cow mood decimals

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -471,15 +471,16 @@ function renderCows() {
             cowCard.classList.add('secret-cow-unlock');
         }
 
-        const happinessColor = cow.isHappy ? '#32CD32' : '#FF6B6B';
-        const heartIcon      = cow.isHappy ? '💚' : '💔';
-        const moodClass      = cow.isHappy ? 'cow-mood cow-mood-happy' : 'cow-mood cow-mood-sad';
+        const happinessColor    = cow.isHappy ? '#32CD32' : '#FF6B6B';
+        const heartIcon         = cow.isHappy ? '💚' : '💔';
+        const moodClass         = cow.isHappy ? 'cow-mood cow-mood-happy' : 'cow-mood cow-mood-sad';
+        const moodValueDisplay  = Math.round(cow.moodValue);
 
         cowCard.innerHTML = `
             <div class="cow-icon">${cow.emoji}</div>
             <div class="cow-name">${cow.name}</div>
             <div class="${moodClass}">
-                ${heartIcon} ${cow.currentMood} (${cow.moodValue})
+                ${heartIcon} ${cow.currentMood} (${moodValueDisplay})
             </div>
             <button class="mood-button" onclick="startMinigame(${idx})">
                 ${cow.isHappy ? 'Keep Happy!' : 'Cheer Up!'}


### PR DESCRIPTION
## Summary
- round cow mood values so cows don't display decimal mood amounts

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686062aa4c148331a740a620a44baa10