### PR TITLE
Base mood bump on minigame results

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1357,9 +1357,11 @@ function endMinigame() {
     const success = currentMinigame.score >= currentMinigame.target;
     
 // --- INSERT MOOD-BUMP HERE -------------------------------
-  // Decide how much to adjust moodValue
-  const moodDelta = success ? 10 : -10;
-  // Clamp between 0 and 100
+  // Adjust mood based on how well or poorly the minigame went
+  const resultDelta = currentMinigame.score - currentMinigame.target;
+  // Translate score difference into a mood change, capped to keep swings reasonable
+  let moodDelta = Math.round(resultDelta / 5);
+  moodDelta = Math.max(-20, Math.min(20, moodDelta));
   cow.moodValue = Math.max(0, Math.min(100, cow.moodValue + moodDelta));
 
   // Recompute currentMood & happiness flags


### PR DESCRIPTION
## Summary
- adjust cow mood up or down based on how much the minigame score beats the target

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6860914ef7808331bab2cd2672fd51a6