### PR TITLE
Fix reset button clearing save data

### DIFF
--- a/saveLoad.js
+++ b/saveLoad.js
@@ -137,7 +137,10 @@ function importGameData() {
 function resetGameData() {
     if (confirm('Are you sure you want to reset all game data? This cannot be undone!')) {
         clearAllCropTimers();
-        
+
+        // Remove any saved data so a fresh game starts on reload
+        localStorage.removeItem(SAVE_KEY);
+
         // Reset to initial state
         gameState = {
             coins: 100,


### PR DESCRIPTION
## Summary
- ensure reset removes saved state from localStorage

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686096cf0c4c8331aca1fc8ba3a1c220