### PR TITLE
Disable keep-happy button when cow maxed out

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -476,14 +476,22 @@ function renderCows() {
         const moodClass         = cow.isHappy ? 'cow-mood cow-mood-happy' : 'cow-mood cow-mood-sad';
         const moodValueDisplay  = Math.round(cow.moodValue);
 
+        const isMaxHappy = cow.happinessLevel >= 100;
+        const buttonText = !cow.isHappy
+            ? 'Cheer Up!'
+            : isMaxHappy
+                ? 'Max Happy!'
+                : 'Keep Happy!';
+        const disabledAttr = isMaxHappy ? 'disabled' : '';
+
         cowCard.innerHTML = `
             <div class="cow-icon">${cow.emoji}</div>
             <div class="cow-name">${cow.name}</div>
             <div class="${moodClass}">
                 ${heartIcon} ${cow.currentMood} (${moodValueDisplay})
             </div>
-            <button class="mood-button" onclick="startMinigame(${idx})">
-                ${cow.isHappy ? 'Keep Happy!' : 'Cheer Up!'}
+            <button class="mood-button" onclick="startMinigame(${idx})" ${disabledAttr}>
+                ${buttonText}
             </button>
         `;
         grid.appendChild(cowCard);

--- a/styles.css
+++ b/styles.css
@@ -228,6 +228,13 @@ body {
     box-shadow: 0 2px 8px rgba(255,107,107,0.4);
 }
 
+.mood-button:disabled {
+    background: linear-gradient(145deg, #999, #777);
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+}
+
 .crops-section {
     background: rgba(255,255,255,0.9);
     border-radius: 20px;


### PR DESCRIPTION
## Summary
- grey out `Keep Happy` button once a cow reaches 100% happiness
- add CSS for disabled mood button

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68609bceba048331aa9dffff4f9a6122