### PR TITLE
Fix Next Day button overlap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -883,7 +883,8 @@ body {
     touch-action: pan-y;
     max-height: calc(100vh - 200px);
     overflow-y: auto;
-    padding-bottom: 70px;
+    /* Extra space so the fixed Next Day button doesn't cover the last items */
+    padding-bottom: 120px;
 }
 
 /* Enhanced visual effects */


### PR DESCRIPTION
## Summary
- enlarge padding on tab sections so fixed Next Day button doesn't overlap content

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68609d24ea28833198284ff62e8bdc93