### PR TITLE
Remove export and import UI

### DIFF
--- a/config.js
+++ b/config.js
@@ -137,7 +137,7 @@ const FARM_TIPS = [
     "Golden cowbell makes cows start happier each day!",
     "Build combos in rhythm games for bonus points!",
     "Secret cows have special unlock conditions!",
-    "Export your save file as backup!",
+    "Auto-save keeps your progress safe!",
     "Watch the unlock progress in the stats tab!",
     "Try different rhythm strategies for each cow!",
     "Timing gets easier with pitchfork upgrades!"

--- a/index.html
+++ b/index.html
@@ -88,15 +88,10 @@
           </div>
           <div class="save-button-grid">
             <button onclick="saveGameState(); showToast('Game saved!', 'success'); updateSaveInfo();" class="save-button save-button-save">&#x1F4BE; Save</button>
-            <button onclick="exportGameData()" class="save-button save-button-export">&#x1F4E4; Export</button>
-          </div>
-          <div class="save-button-grid save-button-grid-no-margin">
-            <button onclick="importGameData()" class="save-button save-button-import">&#x1F4E5; Import</button>
             <button onclick="resetGameData()" class="save-button save-button-reset">&#x1F5D1;&#xFE0F; Reset</button>
           </div>
           <div class="save-help-text">
-            Auto-saves every 2 minutes and when you leave.<br>
-            Export creates a downloadable backup file.
+            Auto-saves every 2 minutes and when you leave.
           </div>
         </div>
         <div class="debug-container">

--- a/styles.css
+++ b/styles.css
@@ -1410,13 +1410,6 @@ body {
     background: linear-gradient(145deg, #32CD32, #228B22);
 }
 
-.save-button-export {
-    background: linear-gradient(145deg, #4169E1, #0000CD);
-}
-
-.save-button-import {
-    background: linear-gradient(145deg, #FF8C00, #FF6347);
-}
 
 .save-button-reset {
     background: linear-gradient(145deg, #DC143C, #B22222);
@@ -1471,9 +1464,6 @@ body {
     box-shadow: 0 4px 15px rgba(50,205,50,0.3);
 }
 
-.save-button-grid-no-margin {
-    margin-bottom: 0;
-}
 
 .debug-container {
     background: linear-gradient(145deg, #FFE4E1, #FFF0F5);


### PR DESCRIPTION
## Summary
- delete Export and Import buttons from the Save System section
- drop the button styles no longer used
- update farm tips now that export is gone

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860c385994083319be4f2dc27dc17d0