### PR TITLE
Update minigame layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,19 +116,21 @@
       <div class="countdown-clock" id="countdownClock">15</div>
     </div>
     <div class="rhythm-game">
-      <div class="rhythm-bar" id="rhythmBar">
-        <div class="rhythm-marker"></div>
-      </div>
-      <div class="score-area">
+      <div class="score-area container">
         <div class="score-display">&#x1F3AF; Score: <span id="currentScore">0</span></div>
         <div class="score-display">&#x1F6A9; Target: <span id="targetScore">100</span></div>
         <div class="score-display">&#x26A1; Combo: <span id="comboCount">0</span></div>
       </div>
+      <div class="rhythm-bar" id="rhythmBar">
+        <div class="rhythm-marker"></div>
+      </div>
     </div>
-    <div class="mobile-controls">
-      <button class="control-btn" id="tapBtn">&#x1F446;<br>TAP</button>
+    <div class="minigame-footer">
+      <div class="mobile-controls">
+        <button class="control-btn" id="tapBtn">&#x1F446;<br>TAP</button>
+      </div>
+      <button class="close-minigame" onclick="closeMinigame()">&#x274C; CLOSE</button>
     </div>
-    <button class="close-minigame" onclick="closeMinigame()">&#x274C; CLOSE</button>
   </div>
 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -587,9 +587,11 @@ body {
     background: rgba(255,255,255,0.9);
     border-radius: 15px;
     padding: 15px;
-    text-align: center;
     box-shadow: 0 4px 15px rgba(0,0,0,0.1);
     margin-bottom: 20px;
+    display: flex;
+    justify-content: space-around;
+    text-align: center;
 }
 
 .score-display {
@@ -602,7 +604,6 @@ body {
 .mobile-controls {
     display: grid;
     gap: 15px;
-    /* margin-top: auto; */
 }
 
 .control-btn {
@@ -641,7 +642,7 @@ body {
     font-family: 'Montserrat', sans-serif;
     font-weight: 800;
     cursor: pointer;
-    margin-top: 15px;
+    margin-top: 0;
     box-shadow: 0 4px 15px rgba(255,107,107,0.3);
     transition: all 0.3s ease;
 }
@@ -654,6 +655,14 @@ body {
 
 .close-minigame:active {
     transform: scale(0.95);
+}
+
+.minigame-footer {
+    margin-top: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 15px;
 }
 
 


### PR DESCRIPTION
## Summary
- reposition rhythm minigame score area above the notes
- place tap and close buttons in new footer container
- show the score values in a flex row
- add styling for new footer and revised score area

## Testing
- `node --check scripts.js`
- `node --check debug.js && node --check config.js && node --check saveLoad.js`

------
https://chatgpt.com/codex/tasks/task_e_6860c98048688331a3e5efdbfba78dc7