### PR TITLE
Ensure moods update on closing minigame

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1556,6 +1556,11 @@ function closeMinigame() {
     }
     const overlay = document.getElementById('minigameOverlay');
     if (overlay) overlay.style.display = 'none';
+
+    // Ensure any mood changes are reflected once the overlay closes
+    updateDisplay();
+    updateBulletin();
+    renderCows();
 }
 
 // Mobile-optimized minigame functions


### PR DESCRIPTION
## Summary
- call UI update functions when closing the minigame overlay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860cc27b6288331a75a39ad09088fbd