### PR TITLE
Improve farm bulletin board layout

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -823,13 +823,15 @@ function updateBulletin() {
     bulletin.innerHTML = `
         <div class="bulletin-container">
             <h3 class="bulletin-title">
-                📋 DAILY FARM REPORT - DAY ${gameState.day}
+                📋 FARM BULLETIN - DAY ${gameState.day}
             </h3>
-            <p class="bulletin-stat"><strong>Happy Cows:</strong> ${happyCows.length}/${totalCows}</p>
-            <p class="bulletin-stat"><strong>Milk Produced:</strong> ${gameState.dailyStats.milkProduced}</p>
-            <p class="bulletin-stat"><strong>Coins Earned:</strong> ${gameState.dailyStats.coinsEarned}</p>
-            <p class="bulletin-stat"><strong>Perfect Scores:</strong> ${gameState.dailyStats.perfectScores}</p>
-            <p class="bulletin-stat"><strong>Total Perfects:</strong> ${gameState.stats.totalPerfectScores}</p>
+            <div class="bulletin-stats-grid">
+                <p class="bulletin-stat">😀 Happy Cows: ${happyCows.length}/${totalCows}</p>
+                <p class="bulletin-stat">🥛 Milk: ${gameState.dailyStats.milkProduced}</p>
+                <p class="bulletin-stat">💰 Coins: ${gameState.dailyStats.coinsEarned}</p>
+                <p class="bulletin-stat">🎯 Perfect Scores: ${gameState.dailyStats.perfectScores}</p>
+                <p class="bulletin-stat">🏆 Total Perfects: ${gameState.stats.totalPerfectScores}</p>
+            </div>
         </div>
         <div class="unlock-progress-box">
             <h4 class="unlock-progress-title">

--- a/styles.css
+++ b/styles.css
@@ -1139,16 +1139,26 @@ body {
 
 .bulletin-title {
     color: #8B4513;
-    margin-bottom: 8px;
+    margin-bottom: 6px;
     font-family: 'Montserrat', sans-serif;
     font-size: 1.1em;
     font-weight: 700;
+    text-align: center;
+}
+
+.bulletin-stats-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
 }
 
 .bulletin-stat {
     font-weight: 800;
     color: #654321;
-    margin: 4px 0;
+    background: rgba(245, 230, 211, 0.7);
+    padding: 4px 6px;
+    border-radius: 6px;
+    font-size: 0.85em;
 }
 
 /* Unlock Progress Box */
@@ -1469,11 +1479,14 @@ body {
 
 /* Stats Tab Containers */
 .bulletin-board {
-    background: linear-gradient(145deg, #F5E6D3, #E8D5B7);
+    background: linear-gradient(145deg, #FBE8B6, #EBCFA2);
     border-radius: 12px;
     padding: 15px;
     border: 2px solid #8B4513;
     box-shadow: 0 4px 15px rgba(139,69,19,0.3);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
 }
 
 .achievements-container {


### PR DESCRIPTION
## Summary
- restyle the bulletin board
- reorganize daily stats with a grid layout

## Testing
- `node --check scripts.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860d29e1740833189c0a6fe86ea4fc9