### PR TITLE
Add minigame legend

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,12 @@
         <div class="score-display">Target: <span id="targetScore">100</span></div>
         <div class="score-display">Combo: <span id="comboCount">0</span></div>
       </div>
+      <div class="minigame-legend">
+        <div class="legend-item"><span class="legend-color legend-perfect"></span>Perfect</div>
+        <div class="legend-item"><span class="legend-color legend-good"></span>Good</div>
+        <div class="legend-item"><span class="legend-color legend-okay"></span>Okay</div>
+        <div class="legend-item"><span class="legend-color legend-miss"></span>Miss</div>
+      </div>
       <div class="rhythm-bar" id="rhythmBar">
         <div class="rhythm-marker"></div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -604,6 +604,33 @@ body {
     margin: 0 5px;
 }
 
+.minigame-legend {
+    display: flex;
+    justify-content: space-around;
+    margin-bottom: 10px;
+    font-size: 0.8em;
+    font-weight: bold;
+    color: #2F5F2F;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.legend-color {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.legend-perfect { background: #00FF00; }
+.legend-good    { background: #FFFF00; }
+.legend-okay    { background: #FF8C00; }
+.legend-miss    { background: #FF0000; }
+
 .mobile-controls {
     display: grid;
     gap: 15px;


### PR DESCRIPTION
## Summary
- add legend section to minigame overlay
- style legend items showing hit quality colors

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860d5f296648331a2577113b761b5ee