### PR TITLE
Add close button for achievement popups

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1078,6 +1078,7 @@ function showAchievementUnlock(achievement) {
     
     popup.className = `achievement-popup achievement-${rarity}`;
     popup.innerHTML = `
+        <button class="close-achievement" onclick="closeAchievementPopup()">&#x274C;</button>
         <div class="achievement-title">Achievement Unlocked!</div>
         <div class="achievement-icon-name">
             ${achievement.icon} ${achievement.name}
@@ -1106,6 +1107,13 @@ function showAchievementUnlock(achievement) {
             legendary: [500, 200, 500, 200, 500, 200, 500]
         };
         navigator.vibrate(vibrationPatterns[rarity] || [100]);
+    }
+}
+
+function closeAchievementPopup() {
+    const popup = document.getElementById('achievementPopup');
+    if (popup) {
+        popup.style.display = 'none';
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -738,6 +738,18 @@ body {
     animation: achievementPulse 2s infinite;
 }
 
+.close-achievement {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    background: transparent;
+    border: none;
+    color: white;
+    font-size: 1.2em;
+    cursor: pointer;
+    font-weight: bold;
+}
+
 .achievement-title {
     font-family: 'Montserrat', sans-serif;
     color: #8B4513;


### PR DESCRIPTION
## Summary
- add close button markup to achievement popup
- style close button and allow manual closing
- add `closeAchievementPopup` helper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860f08471808331a9ccd66d1adb38ec