### PR TITLE
Combo popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,6 @@
       <div class="score-area container">
         <div class="score-display">Score: <span id="currentScore">0</span></div>
         <div class="score-display">Target: <span id="targetScore">100</span></div>
-        <div class="score-display">Combo: <span id="comboCount">0</span></div>
       </div>
       <div class="minigame-legend">
         <div class="legend-item"><span class="legend-color legend-perfect"></span>Perfect</div>

--- a/minigame.js
+++ b/minigame.js
@@ -31,7 +31,6 @@ function startRhythmGame(cowIndex) {
 
     document.getElementById('currentScore').textContent = '0';
     document.getElementById('targetScore').textContent = currentMinigame.target;
-    document.getElementById('comboCount').textContent = '0';
     const countdownEl = document.getElementById('countdownClock');
     if (countdownEl) countdownEl.textContent = currentMinigame.timeLeft;
 
@@ -157,7 +156,6 @@ function spawnNote() {
             note.parentNode.removeChild(note);
             // Miss penalty
             currentMinigame.combo = 0;
-            document.getElementById('comboCount').textContent = currentMinigame.combo;
         }
     }, duration);
 }
@@ -222,12 +220,15 @@ function hitNote(note) {
     currentMinigame.maxCombo = Math.max(currentMinigame.maxCombo, currentMinigame.combo);
     
     document.getElementById('currentScore').textContent = currentMinigame.score;
-    document.getElementById('comboCount').textContent = currentMinigame.combo;
     
     if (points > 0) {
         showFloatingText(`+${points}!`, noteRect.left, noteRect.top);
     }
-    
+
+    if (currentMinigame.combo >= 3 && hitQuality !== 'miss') {
+        showComboPopup(currentMinigame.combo);
+    }
+
     note.remove();
 }
 
@@ -238,10 +239,21 @@ function showFloatingText(text, x, y) {
     floatingText.style.position = 'fixed';
     floatingText.style.left = x + 'px';
     floatingText.style.top = y + 'px';
-    
+
     document.body.appendChild(floatingText);
-    
+
     setTimeout(() => floatingText.remove(), 1000);
+}
+
+function showComboPopup(combo) {
+    const popup = document.createElement('div');
+    popup.textContent = `Combo x${combo}!`;
+    popup.className = 'floating-text';
+    popup.style.left = '50%';
+    popup.style.top = '80px';
+    popup.style.transform = 'translateX(-50%)';
+    document.body.appendChild(popup);
+    setTimeout(() => popup.remove(), 1000);
 }
 
 function endMinigame() {


### PR DESCRIPTION
## Summary
- remove always-on combo display
- show combo popup once combo reaches 3 hits

## Testing
- `python3 -m py_compile *.py` *(fails: no Python files)*

------
https://chatgpt.com/codex/tasks/task_e_6861569c05848331b1a0c40d78055922