### PR TITLE
Add popup results after minigame

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,7 @@
 <!-- Mobile Toast Messages -->
 <div class="toast-message" id="toastMessage"></div>
 <div class="achievement-popup" id="achievementPopup"></div>
+<div class="result-popup" id="minigameResultPopup"></div>
 
 <script src="config.js?v=moo3.8"></script>
 <script src="saveLoad.js?v=1.0"></script>

--- a/minigame.js
+++ b/minigame.js
@@ -271,6 +271,7 @@ function endMinigame() {
     
     const cow = gameState.cows[currentMinigame.cowIndex];
     const success = currentMinigame.score >= currentMinigame.target;
+    let resultMessage = '';
     
 // --- INSERT MOOD-BUMP HERE -------------------------------
   // Adjust mood based on how well or poorly the minigame went
@@ -345,13 +346,15 @@ function endMinigame() {
             gameState.stats.totalPerfectScores++;
             gameState.stats.currentPerfectStreak++;
             gameState.stats.perfectStreak = Math.max(gameState.stats.perfectStreak, gameState.stats.currentPerfectStreak);
-            
+
             milkReward += 25;
             coinReward += 35;
+            resultMessage = `🎉 PERFECT! ${cow.name} is ecstatic!<br>+${milkReward} milk, +${coinReward} coins!<br>Max Combo: ${currentMinigame.maxCombo}`;
             showToast(`🎉 PERFECT! ${cow.name} is ecstatic!\n+${milkReward} milk, +${coinReward} coins!\nMax Combo: ${currentMinigame.maxCombo}`, 'success');
             if (navigator.vibrate) navigator.vibrate([200, 100, 200, 100, 200]);
         } else {
             gameState.stats.currentPerfectStreak = 0; // Reset streak
+            resultMessage = `🎉 Success! ${cow.name} is happy!<br>+${milkReward} milk, +${coinReward} coins!<br>Max Combo: ${currentMinigame.maxCombo}`;
             showToast(`🎉 Success! ${cow.name} is happy!\n+${milkReward} milk, +${coinReward} coins!\nMax Combo: ${currentMinigame.maxCombo}`, 'success');
             if (navigator.vibrate) navigator.vibrate([100, 50, 100]);
         }
@@ -378,7 +381,8 @@ function endMinigame() {
         gameState.coins = Math.max(0, gameState.coins - coinLoss);
         cow.isHappy = false;
         cow.happinessLevel = Math.max(1, cow.happinessLevel - 10);
-        
+
+        resultMessage = `😤 ${cow.name} is not impressed!<br>-${coinLoss} coins.<br>Max Combo: ${currentMinigame.maxCombo}`;
         showToast(`😤 ${cow.name} is not impressed! -${coinLoss} coins.\nMax Combo: ${currentMinigame.maxCombo}`, 'failure');
         if (navigator.vibrate) navigator.vibrate(300);
     }
@@ -387,17 +391,35 @@ function endMinigame() {
     updateBulletin();
     renderCows();
     checkAchievements(); // Check for new achievements
-    
+
     // Auto-save after minigame
     if (success || gameState.stats.totalPerfectScores > 0) {
         saveGameState();
         updateSaveInfo();
     }
+
+    showMinigameResult(resultMessage);
 }
 
 function clearNotes() {
     const notes = document.querySelectorAll('.rhythm-note');
     notes.forEach(note => note.remove());
+}
+
+function showMinigameResult(message) {
+    const popup = document.getElementById('minigameResultPopup');
+    if (!popup) return;
+
+    popup.innerHTML = `
+        <button class="close-result" onclick="closeResultPopup()">&#x274C;</button>
+        <div class="result-text">${message}</div>
+    `;
+    popup.style.display = 'block';
+}
+
+function closeResultPopup() {
+    const popup = document.getElementById('minigameResultPopup');
+    if (popup) popup.style.display = 'none';
 }
 
 function closeMinigame() {
@@ -406,6 +428,7 @@ function closeMinigame() {
     }
     const overlay = document.getElementById('minigameOverlay');
     if (overlay) overlay.style.display = 'none';
+    closeResultPopup();
 
     // Ensure any mood changes are reflected once the overlay closes
     updateDisplay();

--- a/styles.css
+++ b/styles.css
@@ -738,6 +738,35 @@ body {
     animation: achievementPulse 2s infinite;
 }
 
+.result-popup {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: linear-gradient(145deg, #FFF8DC, #F5DEB3);
+    padding: 20px;
+    border-radius: 15px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+    z-index: 1003;
+    max-width: 85%;
+    text-align: center;
+    display: none;
+    touch-action: none;
+    border: 3px solid #8B4513;
+}
+
+.close-result {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    background: transparent;
+    border: none;
+    color: #8B4513;
+    font-size: 1.2em;
+    cursor: pointer;
+    font-weight: bold;
+}
+
 .close-achievement {
     position: absolute;
     top: 5px;


### PR DESCRIPTION
## Summary
- add a minigame result popup element
- style popup and close button
- show minigame results in a popup when the game ends

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68615807f8b48331b750d53fbd4fa472