### PR TITLE
Fix minigame legend colours

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
         <div class="score-display">Target: <span id="targetScore">100</span></div>
       </div>
       <div class="minigame-legend">
+        <div class="legend-caption">Note colors show your timing:</div>
         <div class="legend-item"><span class="legend-color legend-perfect"></span>Perfect</div>
         <div class="legend-item"><span class="legend-color legend-good"></span>Good</div>
         <div class="legend-item"><span class="legend-color legend-okay"></span>Okay</div>

--- a/minigame.js
+++ b/minigame.js
@@ -153,7 +153,11 @@ function spawnNote() {
     
     setTimeout(() => {
         if (note.parentNode) {
-            note.parentNode.removeChild(note);
+            // Visual feedback for missing a note
+            note.style.background = '#FF0000';
+            setTimeout(() => {
+                if (note.parentNode) note.parentNode.removeChild(note);
+            }, 200);
             // Miss penalty
             currentMinigame.combo = 0;
         }
@@ -204,6 +208,7 @@ function hitNote(note) {
     } else {
         currentMinigame.combo = 0;
         hitQuality = 'miss';
+        note.style.background = '#FF0000';
     }
     
     // Apply combo bonus

--- a/styles.css
+++ b/styles.css
@@ -611,6 +611,14 @@ body {
     font-size: 0.8em;
     font-weight: bold;
     color: #2F5F2F;
+    flex-wrap: wrap;
+}
+
+.legend-caption {
+    flex-basis: 100%;
+    text-align: center;
+    font-weight: normal;
+    margin-bottom: 4px;
 }
 
 .legend-item {


### PR DESCRIPTION
## Summary
- clarify legend caption and match note colours when missed
- show red flash when notes are missed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68615837fb8483318cb487e476fccbfa