### PR TITLE
Adjust cowbell happiness bonus

### DIFF
--- a/config.js
+++ b/config.js
@@ -43,7 +43,7 @@ const GAME_CONFIG = {
         },
         cowbell: {
             happiness_threshold: 0.2, // Higher chance of starting happy
-            happiness_bonus: 51 // Starting happiness level minimum
+            happiness_bonus: 40 // Starting happiness level minimum
         }
     },
 


### PR DESCRIPTION
## Summary
- reduce the `happiness_bonus` for the cowbell upgrade from 51 to 40

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_686160d49e148331927eef4f46bf7518