### PR TITLE
Update metronome cost

### DIFF
--- a/shop.json
+++ b/shop.json
@@ -58,7 +58,7 @@
       "description": "Perfect timing assistance!",
       "icon": "\uD83C\uDFB5",
       "category": "tools",
-      "cost": 150,
+      "cost": 200,
       "maxLevel": 1,
       "effects": {
         "rhythm_speed_bonus": 0.3


### PR DESCRIPTION
## Summary
- update `metronome_1` shop item cost from 150 to 200

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686160d7d1308331a6fc096287089107