### PR TITLE
Adjust Energy Drink duration

### DIFF
--- a/shop.json
+++ b/shop.json
@@ -137,7 +137,7 @@
       "maxLevel": 99,
       "effects": {
         "action_speed_boost": 0.2,
-        "duration": 1800000
+        "duration": 1200000
       },
       "unlockCondition": {
         "type": "day",


### PR DESCRIPTION
## Summary
- update the Energy Drink consumable duration to 20 minutes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686160e439c883319fb4cb866638f021