### PR TITLE
Tune combo bonus threshold

### DIFF
--- a/config.js
+++ b/config.js
@@ -64,7 +64,7 @@ const GAME_CONFIG = {
 
     // Combo system
     COMBO: {
-        bonus_threshold: 5, // Combo hits needed for bonus
+        bonus_threshold: 8, // Combo hits needed for bonus
         bonus_points_per_threshold: 5
     },
 


### PR DESCRIPTION
## Summary
- adjust COMBO bonus threshold in `config.js` to make combos a bit harder

## Testing
- `grep -n "bonus_threshold" config.js`

------
https://chatgpt.com/codex/tasks/task_e_6861610e83348331b60e2d2e7ee003a5