### PR TITLE
Update happiness default chance

### DIFF
--- a/config.js
+++ b/config.js
@@ -84,7 +84,7 @@ const GAME_CONFIG = {
 
     // Happiness system
     HAPPINESS: {
-        default_chance: 0.3, // 30% chance to start happy
+        default_chance: 0.25, // 25% chance to start happy
         level_min: 1,
         level_max: 100,
         success_bonus: 20,


### PR DESCRIPTION
## Summary
- tweak happiness system configuration so the default chance to start happy is 25%

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68616112651c8331ba0e203a8a64fbbd