### PR TITLE
Adjust happiness decay in config

### DIFF
--- a/config.js
+++ b/config.js
@@ -89,8 +89,8 @@ const GAME_CONFIG = {
         level_max: 100,
         success_bonus: 20,
         failure_penalty: 10,
-        // Mood decreases by 5% of the current value every hour
-        decay_rate_percent: 0.05
+        // Mood decreases by about 3% of the current value every hour
+        decay_rate_percent: 0.03
     },
 
     HAPPINESS_UPDATE_INTERVAL: 3600000, // 1 hour


### PR DESCRIPTION
## Summary
- reduce happiness decay rate to 0.03 in `config.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68616156b25c8331a556311a6c84c1d7