### PR TITLE
Remove extra toast popup after minigame

### DIFF
--- a/minigame.js
+++ b/minigame.js
@@ -355,12 +355,10 @@ function endMinigame() {
             milkReward += 20;
             coinReward += 25;
             resultMessage = `🎉 PERFECT! ${cow.name} is ecstatic!<br>+${milkReward} milk, +${coinReward} coins!<br>Max Combo: ${currentMinigame.maxCombo}`;
-            showToast(`🎉 PERFECT! ${cow.name} is ecstatic!\n+${milkReward} milk, +${coinReward} coins!\nMax Combo: ${currentMinigame.maxCombo}`, 'success');
             if (navigator.vibrate) navigator.vibrate([200, 100, 200, 100, 200]);
         } else {
             gameState.stats.currentPerfectStreak = 0; // Reset streak
             resultMessage = `🎉 Success! ${cow.name} is happy!<br>+${milkReward} milk, +${coinReward} coins!<br>Max Combo: ${currentMinigame.maxCombo}`;
-            showToast(`🎉 Success! ${cow.name} is happy!\n+${milkReward} milk, +${coinReward} coins!\nMax Combo: ${currentMinigame.maxCombo}`, 'success');
             if (navigator.vibrate) navigator.vibrate([100, 50, 100]);
         }
         
@@ -382,7 +380,6 @@ function endMinigame() {
         cow.happinessLevel = Math.max(1, cow.happinessLevel - 10);
 
         resultMessage = `😤 ${cow.name} is not impressed!<br>-${coinLoss} coins.<br>Max Combo: ${currentMinigame.maxCombo}`;
-        showToast(`😤 ${cow.name} is not impressed! -${coinLoss} coins.\nMax Combo: ${currentMinigame.maxCombo}`, 'failure');
         if (navigator.vibrate) navigator.vibrate(300);
     }
     


### PR DESCRIPTION
## Summary
- remove toast messages at the end of the rhythm minigame

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861d0c6841c8331aba5ec186676b0a1