### PR TITLE
Fix dynamic legend colors

### DIFF
--- a/minigame.js
+++ b/minigame.js
@@ -10,6 +10,35 @@ let currentMinigame = {
     maxCombo: 0
 };
 
+// Default colors for hit feedback. These may be overridden by rhythmPatterns.hitColors
+const DEFAULT_HIT_COLORS = {
+    perfect: '#00FF00',
+    good: '#FFFF00',
+    okay: '#FF8C00',
+    miss: '#FF0000'
+};
+
+function getHitColor(type) {
+    if (rhythmPatterns.hitColors && rhythmPatterns.hitColors[type]) {
+        return rhythmPatterns.hitColors[type];
+    }
+    return DEFAULT_HIT_COLORS[type];
+}
+
+function updateMinigameLegend() {
+    const legendMap = {
+        perfect: document.querySelector('.legend-perfect'),
+        good: document.querySelector('.legend-good'),
+        okay: document.querySelector('.legend-okay'),
+        miss: document.querySelector('.legend-miss')
+    };
+    for (const key in legendMap) {
+        if (legendMap[key]) {
+            legendMap[key].style.background = getHitColor(key);
+        }
+    }
+}
+
 function getRandomGameType() {
     const types = rhythmPatterns.rhythmTypes ? Object.keys(rhythmPatterns.rhythmTypes) : [];
     if (types.length === 0) return 'smooth';
@@ -154,7 +183,7 @@ function spawnNote() {
     setTimeout(() => {
         if (note.parentNode) {
             // Visual feedback for missing a note
-            note.style.background = '#FF0000';
+            note.style.background = getHitColor('miss');
             setTimeout(() => {
                 if (note.parentNode) note.parentNode.removeChild(note);
             }, 200);
@@ -192,23 +221,23 @@ function hitNote(note) {
         points = basePoints;
         hitQuality = 'perfect';
         currentMinigame.combo++;
-        note.style.background = '#00FF00';
+        note.style.background = getHitColor('perfect');
         if (navigator.vibrate) navigator.vibrate(50);
     } else if (distance < 80 * baseTolerance) {
         points = Math.floor(basePoints * 0.7);
         hitQuality = 'good';
         currentMinigame.combo++;
-        note.style.background = '#FFFF00';
+        note.style.background = getHitColor('good');
         if (navigator.vibrate) navigator.vibrate(30);
     } else if (distance < 120 * baseTolerance) {
         points = Math.floor(basePoints * 0.4);
         hitQuality = 'okay';
         currentMinigame.combo = Math.max(0, currentMinigame.combo - 1);
-        note.style.background = '#FF8C00';
+        note.style.background = getHitColor('okay');
     } else {
         currentMinigame.combo = 0;
         hitQuality = 'miss';
-        note.style.background = '#FF0000';
+        note.style.background = getHitColor('miss');
     }
     
     // Apply combo bonus
@@ -446,9 +475,11 @@ function startMinigame(cowIndex) {
     const instructions = document.getElementById('minigameInstructions');
     
     if (!overlay || !title || !instructions) return;
-    
+
     title.innerHTML = `${cow.emoji} ${cow.name}'s ${cow.currentGameType.toUpperCase()} Challenge!`;
     instructions.textContent = getGameInstructions(cow.currentGameType);
+
+    updateMinigameLegend();
 
     // Hide the close button until the game is finished
     const closeBtn = document.querySelector('.close-minigame');
@@ -464,6 +495,9 @@ function startMinigame(cowIndex) {
 // Mobile touch controls for minigame - using DOMContentLoaded to avoid timing issues
 document.addEventListener('DOMContentLoaded', function() {
     const tapBtn = document.getElementById('tapBtn');
+
+    // Ensure legend colors match the hit feedback colors
+    updateMinigameLegend();
     
     if (tapBtn) {
         tapBtn.addEventListener('touchstart', (e) => {

--- a/rhythm-patterns.json
+++ b/rhythm-patterns.json
@@ -177,5 +177,11 @@
       "points": 25,
       "effect": "synth_wave"
     }
+  },
+  "hitColors": {
+    "perfect": "#00FF00",
+    "good": "#FFFF00",
+    "okay": "#FF8C00",
+    "miss": "#FF0000"
   }
 }

--- a/scripts.js
+++ b/scripts.js
@@ -16,7 +16,7 @@ async function loadGameData() {
             fetch('cows.json?v=moo3.5'),
             fetch('crops.json?v=1.2'),
             fetch('shop.json?v=1.2'), 
-            fetch('rhythm-patterns.json?v=1.2'),
+            fetch('rhythm-patterns.json?v=1.3'),
             fetch('achievements.json?v=1.2')
         ]);
 


### PR DESCRIPTION
## Summary
- introduce `hitColors` in `rhythm-patterns.json`
- load hitColors via `getHitColor` helper
- color minigame legend and notes using the helper
- bump rhythm-patterns fetch version

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861d0ab57b08331b527d4ea84619476