### PR TITLE
Expose startMinigame globally

### DIFF
--- a/minigame.js
+++ b/minigame.js
@@ -502,6 +502,9 @@ function startMinigame(cowIndex) {
         navigator.vibrate(100);
     }
 }
+
+// Ensure the minigame function is available globally for inline event handlers
+window.startMinigame = startMinigame;
 // Mobile touch controls for minigame - using DOMContentLoaded to avoid timing issues
 document.addEventListener('DOMContentLoaded', function() {
     const tapBtn = document.getElementById('tapBtn');


### PR DESCRIPTION
## Summary
- expose `startMinigame` on the global `window` object so inline event handlers can find it

## Testing
- `node -c minigame.js`

------
https://chatgpt.com/codex/tasks/task_e_6861d5677fc88331ab0d76ce39d3c463