### PR TITLE
Add crop growth progress bars

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -300,6 +300,22 @@ body {
     margin-top: 2px;
 }
 
+.growth-progress {
+    width: 80%;
+    height: 6px;
+    background: #ddd;
+    border-radius: 3px;
+    overflow: hidden;
+    margin-top: 2px;
+}
+
+.growth-bar {
+    height: 100%;
+    background: #32CD32;
+    width: 0;
+    transition: width 0.3s linear;
+}
+
 .plant-controls {
     display: grid;
     grid-template-columns: repeat(3, 1fr);


### PR DESCRIPTION
## Summary
- compute remaining grow time when rendering crops
- add progress bar elements inside crop tiles
- update progress bars from crop timer interval function

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6861da1a8a908331a1b4bdf8a7bbfe53