### PR TITLE
Implement new item badges

### DIFF
--- a/saveLoad.js
+++ b/saveLoad.js
@@ -153,6 +153,10 @@ function resetGameData() {
             cows: [],
             lockedCows: [],
             crops: [],
+            unlockedCrops: [],
+            newUnlockedCrops: [],
+            unlockedShopItems: [],
+            newUnlockedShopItems: [],
             upgrades: {},
             effects: {},
             dailyStats: {

--- a/styles.css
+++ b/styles.css
@@ -136,6 +136,19 @@ body {
     display: block;
 }
 
+.new-badge {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    background: #FF4500;
+    color: #fff;
+    padding: 2px 4px;
+    border-radius: 6px;
+    font-size: 0.6em;
+    font-weight: bold;
+    pointer-events: none;
+}
+
 @keyframes fadeIn {
     from {
         opacity: 0;
@@ -319,6 +332,7 @@ body {
     transition: all 0.3s ease;
     touch-action: manipulation;
     box-shadow: 0 4px 12px rgba(50,205,50,0.3);
+    position: relative;
 }
 
 .plant-btn:hover {
@@ -361,6 +375,7 @@ body {
     box-shadow: 0 4px 15px rgba(0,0,0,0.1);
     transition: all 0.3s ease;
     border: 2px solid rgba(135,206,235,0.3);
+    position: relative;
 }
 
 .shop-item:hover {


### PR DESCRIPTION
## Summary
- track newly unlocked crops and shop items in game state
- flag newly unlocked cows
- add `New!` badge to crop buttons, cow cards and shop items
- clear badges when the player views the tab
- style `new-badge` in CSS and position relative elements

## Testing
- `node --check scripts.js`
- `node --check saveLoad.js`

------
https://chatgpt.com/codex/tasks/task_e_6861da8d9c0c83319801faf94637bd3c