### PR TITLE
Remove seasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,5 @@ Modify the JSON files to add new cows, crops, shop items or rhythm patterns. Ref
 - Plant and harvest crops for additional income.
 - Spend coins or milk on upgrades in the shop.
 - Unlock more content as you progress through the days.
-- Seasons rotate every 10 days, changing crop growth speed and cow mood.
 
 The game automatically saves progress and works in modern browsers with JavaScript enabled.

--- a/achievements.json
+++ b/achievements.json
@@ -1013,8 +1013,8 @@
       "rarity": "uncommon"
     },
     {
-      "id": "seasoned_farmer",
-      "name": "Seasoned Farmer",
+      "id": "expert_farmer",
+      "name": "Expert Farmer",
       "description": "Reach day 40",
       "icon": "\ud83c\udf96",
       "category": "progression",
@@ -1024,7 +1024,7 @@
       },
       "reward": {
         "coins": 600,
-        "message": "Seasoned farming skills!"
+        "message": "Expert farming skills!"
       },
       "rarity": "rare"
     },

--- a/config.js
+++ b/config.js
@@ -29,15 +29,6 @@ const GAME_CONFIG = {
     CROP_SLOTS: 12,
     CROP_UPDATE_INTERVAL: 1000, // 1 second
 
-    // Seasonal settings
-    SEASON_LENGTH: 10, // Days per season
-    SEASONS: [
-        { name: 'Spring', emoji: '🌱', cropGrowthMultiplier: 0.9, happinessMultiplier: 1.05 },
-        { name: 'Summer', emoji: '☀️', cropGrowthMultiplier: 1.0, happinessMultiplier: 1.1 },
-        { name: 'Autumn', emoji: '🍂', cropGrowthMultiplier: 1.0, happinessMultiplier: 1.0 },
-        { name: 'Winter', emoji: '❄️', cropGrowthMultiplier: 1.25, happinessMultiplier: 0.9 }
-    ],
-
     // Upgrade settings
     UPGRADES: {
         pitchfork: {
@@ -150,7 +141,6 @@ const FARM_TIPS = [
     "Watch the unlock progress in the stats tab!",
     "Try different rhythm strategies for each cow!",
     "Timing gets easier with pitchfork upgrades!",
-    "Seasons change every 10 days and affect your farm!"
 ];
 
 // Export config for use in other files

--- a/index.html
+++ b/index.html
@@ -27,8 +27,6 @@
       <div class="stat"> <span class="stat-value" id="day">1</span>
         <div class="stat-label">&#x1F4C5; Day</div>
       </div>
-      <div class="stat"> <span class="stat-value" id="season">Spring</span>
-        <div class="stat-label">&#x1F342; Season</div>
       </div>
     </div>
   </div>

--- a/saveLoad.js
+++ b/saveLoad.js
@@ -181,7 +181,6 @@ function resetGameData() {
             },
             perfectStreakRecord: 0,
             activeCropTimers: [],
-            currentSeasonIndex: 0,
             playerID: generateDeviceID(),
             lastSaved: null,
             gameVersion: "2.1"


### PR DESCRIPTION
## Summary
- eliminate seasonal config and tip
- strip season display from the UI
- drop season logic in scripts
- rename `seasoned_farmer` achievement to `expert_farmer`
- keep header stat variables for day and mood

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863fe7f82888331906394e16dc8986a