### PR TITLE
Add white background to stats chart container

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1596,6 +1596,7 @@ body {
 }
 .stats-chart-container {
     margin: 12px 0;
+    background: #ffffff;
 }
 
 #statsChart {


### PR DESCRIPTION
## Summary
- style the `stats-chart-container` with a white background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864094b2a9883318fd34b515b88b70b