### PR TITLE
Fix score display decimal issue

### DIFF
--- a/minigame.js
+++ b/minigame.js
@@ -253,8 +253,10 @@ function hitNote(note) {
     
     currentMinigame.score += points;
     currentMinigame.maxCombo = Math.max(currentMinigame.maxCombo, currentMinigame.combo);
-    
-    document.getElementById('currentScore').textContent = currentMinigame.score;
+
+    // Ensure displayed score never shows decimals
+    const displayScore = Math.floor(currentMinigame.score);
+    document.getElementById('currentScore').textContent = displayScore;
     
     if (points > 0) {
         showFloatingText(`+${points}!`, noteRect.left, noteRect.top);


### PR DESCRIPTION
## Summary
- round currentScore display to avoid decimals

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68640a8e2c848331a61565bd635e6012