### PR TITLE
Disable day-based cow unlocking

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -548,7 +548,7 @@ function getUnlockText(cow) {
         return `Earn ${cow.unlockTarget} coins (${gameState.stats.totalCoinsEarned}/${cow.unlockTarget})`;
     }
     if (cow.unlockCondition === 'day') {
-        return `Reach day ${cow.unlockTarget} (${gameState.day}/${cow.unlockTarget})`;
+        return 'Unlocked by default';
     }
     return 'Unlock requirement unknown';
 }
@@ -997,7 +997,7 @@ function checkAllCowUnlocks() {
             unlocked = true;
         } else if (cow.unlockCondition === 'totalCoins' && gameState.stats.totalCoinsEarned >= cow.unlockTarget) {
             unlocked = true;
-        } else if (cow.unlockCondition === 'day' && gameState.day >= cow.unlockTarget) {
+        } else if (cow.unlockCondition === 'day') {
             unlocked = true;
         } else if (cow.unlockCondition === 'perfectScores' && gameState.stats.totalPerfectScores >= cow.unlockTarget) {
             unlocked = true;


### PR DESCRIPTION
## Summary
- update unlock text for day-based cows
- unlock cows with a day requirement immediately

## Testing
- `node --check scripts.js`
- `for f in *.js; do node --check $f; done`

------
https://chatgpt.com/codex/tasks/task_e_68640c0b00bc83318c51b047582c170f