### PR TITLE
Fix initial cow unlock count

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -548,7 +548,7 @@ function getUnlockText(cow) {
         return `Earn ${cow.unlockTarget} coins (${gameState.stats.totalCoinsEarned}/${cow.unlockTarget})`;
     }
     if (cow.unlockCondition === 'day') {
-        return 'Unlocked by default';
+        return `Reach day ${cow.unlockTarget} (${gameState.day}/${cow.unlockTarget})`;
     }
     return 'Unlock requirement unknown';
 }
@@ -997,7 +997,7 @@ function checkAllCowUnlocks() {
             unlocked = true;
         } else if (cow.unlockCondition === 'totalCoins' && gameState.stats.totalCoinsEarned >= cow.unlockTarget) {
             unlocked = true;
-        } else if (cow.unlockCondition === 'day') {
+        } else if (cow.unlockCondition === 'day' && gameState.day >= (cow.unlockTarget || 1)) {
             unlocked = true;
         } else if (cow.unlockCondition === 'perfectScores' && gameState.stats.totalPerfectScores >= cow.unlockTarget) {
             unlocked = true;


### PR DESCRIPTION
## Summary
- show the required day in the unlock tooltip
- only unlock day-based cows when the target day is reached

## Testing
- `node -c scripts.js`

------
https://chatgpt.com/codex/tasks/task_e_686413361c9883318f9e54c525d6f9b7