### PR TITLE
Implement time-of-day themes

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1742,3 +1742,25 @@ setInterval(() => {
 
 // Update active effect timers every second
 setInterval(renderEffectTimers, 1000);
+
+// Update time-of-day theme based on real-world time
+function updateTimeTheme() {
+    const hour = new Date().getHours();
+    let theme = 'day';
+    if (hour >= 5 && hour < 8) {
+        theme = 'dawn';
+    } else if (hour >= 8 && hour < 18) {
+        theme = 'day';
+    } else if (hour >= 18 && hour < 21) {
+        theme = 'dusk';
+    } else {
+        theme = 'night';
+    }
+    const root = document.body;
+    root.classList.remove('dawn', 'day', 'dusk', 'night');
+    root.classList.add(theme);
+}
+
+// Apply the theme immediately and update every hour
+updateTimeTheme();
+setInterval(updateTimeTheme, 60 * 60 * 1000);

--- a/styles.css
+++ b/styles.css
@@ -1652,3 +1652,21 @@ body {
 .debug-button-green {
     background: linear-gradient(145deg, #32CD32, #228B22);
 }
+
+/* Time-of-day theme backgrounds */
+body.dawn {
+    background: linear-gradient(135deg, #FFE5B4 0%, #FFD59E 100%);
+}
+
+body.day {
+    background: linear-gradient(135deg, #E6A853 0%, #D4941E 100%);
+}
+
+body.dusk {
+    background: linear-gradient(135deg, #FDB99B 0%, #CF8E80 100%);
+}
+
+body.night {
+    background: linear-gradient(135deg, #2C3E50 0%, #4B79A1 100%);
+    color: #FFFFFF;
+}


### PR DESCRIPTION
## Summary
- define dawn, day, dusk and night CSS classes
- add JS to set page theme based on real time and refresh hourly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864299f5d04833182c8ee666dc43477