### PR TITLE
Add lighting & furniture shop categories

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -247,12 +247,12 @@ function renderShop() {
     categoriesContainer.innerHTML = '';
 
     shopData.categories.forEach(category => {
-        // Get items for this category that are unlocked
-        const categoryItems = shopData.items.filter(item =>
-            item.category === category.id && checkShopUnlockCondition(item)
-        );
-
+        // Get all items for this category
+        const categoryItems = shopData.items.filter(item => item.category === category.id);
         if (categoryItems.length === 0) return;
+
+        // Only display unlocked items
+        const unlockedItems = categoryItems.filter(item => checkShopUnlockCondition(item));
 
         const section = document.createElement('div');
         section.className = 'shop-category-section';
@@ -272,7 +272,14 @@ function renderShop() {
         itemGrid.className = 'shop-grid';
 
         // Add items for this category
-        categoryItems.forEach(item => {
+        if (unlockedItems.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'shop-empty';
+            empty.textContent = 'No items unlocked yet';
+            itemGrid.appendChild(empty);
+        }
+
+        unlockedItems.forEach(item => {
             const shopItem = document.createElement('div');
             shopItem.className = 'shop-item';
             

--- a/shop.json
+++ b/shop.json
@@ -19,6 +19,16 @@
       "id": "consumables",
       "name": "\uD83C\uDF4E Consumables",
       "description": "Temporary boosts and effects!"
+    },
+    {
+      "id": "lighting",
+      "name": "\uD83D\uDCA1 Lighting",
+      "description": "Illuminate your farm in style!"
+    },
+    {
+      "id": "furniture",
+      "name": "\uD83D\uDECB Furniture",
+      "description": "Decorate with comfy furnishings!"
     }
   ],
   "items": [
@@ -298,6 +308,58 @@
       "effects": {
         "coin_bonus": 0.05,
         "duration": 3600000
+      },
+      "unlockCondition": null
+    },
+    {
+      "id": "string_lights",
+      "name": "String Lights",
+      "description": "Adds charming lighting to your farm!",
+      "icon": "\uD83D\uDCA1",
+      "category": "lighting",
+      "cost": 150,
+      "maxLevel": 1,
+      "effects": {
+        "happiness_bonus": 0.05
+      },
+      "unlockCondition": null
+    },
+    {
+      "id": "lamp_post",
+      "name": "Lamp Post",
+      "description": "Brightens paths for evening chores.",
+      "icon": "\uD83D\uDEA6",
+      "category": "lighting",
+      "cost": 200,
+      "maxLevel": 1,
+      "effects": {
+        "happiness_bonus": 0.07
+      },
+      "unlockCondition": null
+    },
+    {
+      "id": "farm_bench",
+      "name": "Farm Bench",
+      "description": "A cozy place to rest.",
+      "icon": "\uD83E\uDE91",
+      "category": "furniture",
+      "cost": 120,
+      "maxLevel": 1,
+      "effects": {
+        "happiness_bonus": 0.05
+      },
+      "unlockCondition": null
+    },
+    {
+      "id": "cozy_sofa",
+      "name": "Cozy Sofa",
+      "description": "Comfort boosts happiness by 10%!",
+      "icon": "\uD83D\uDECB",
+      "category": "furniture",
+      "cost": 300,
+      "maxLevel": 1,
+      "effects": {
+        "happiness_bonus": 0.1
       },
       "unlockCondition": null
     }

--- a/styles.css
+++ b/styles.css
@@ -370,6 +370,12 @@ body {
     gap: 12px;
 }
 
+.shop-empty {
+    color: #666;
+    font-style: italic;
+    padding: 10px;
+}
+
 /* Shop tab layout */
 .shop-categories {
     display: flex;


### PR DESCRIPTION
## Summary
- extend `shop.json` with lighting and furniture categories
- add decorative items for the new categories
- improve `renderShop` to show placeholders for locked items
- style `.shop-empty` element

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('shop.json','utf8'));console.log('JSON valid');"`
- `node --check scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_68642a3d203083319f4721befd3a3a60