### PR TITLE
Add time-of-day lighting and crop slowdowns

### DIFF
--- a/config.js
+++ b/config.js
@@ -29,6 +29,11 @@ const GAME_CONFIG = {
     CROP_SLOTS: 12,
     CROP_UPDATE_INTERVAL: 1000, // 1 second
 
+    // Day/night cycle
+    DAY_START_HOUR: 6,
+    DAY_END_HOUR: 18,
+    NIGHT_GROWTH_MULTIPLIER: 1.5,
+
     // Upgrade settings
     UPGRADES: {
         pitchfork: {

--- a/index.html
+++ b/index.html
@@ -109,6 +109,9 @@
       <button class="action-btn" onclick="nextDay()">&#x2600;&#xFE0F; NEXT DAY</button>
     </div>
   </div>
+
+  <!-- Weather / Lighting Overlay -->
+  <div id="weatherOverlay" class="weather-overlay"></div>
 </div>
 
 <!-- Mobile Minigame Overlay -->

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
   </div>
 
   <!-- Weather / Lighting Overlay -->
-  <div id="weatherOverlay" class="weather-overlay"></div>
+  <div id="weatherOverlay" class="weather-overlay weather-day"></div>
 </div>
 
 <!-- Mobile Minigame Overlay -->

--- a/scripts.js
+++ b/scripts.js
@@ -172,14 +172,19 @@ function updateSeason() {
 
 function isNightTime() {
     const hour = new Date().getHours();
-    return hour < 6 || hour >= 18;
+    return (
+        hour < GAME_CONFIG.DAY_START_HOUR ||
+        hour >= GAME_CONFIG.DAY_END_HOUR
+    );
 }
 
 function getTimeOfDay() {
     const hour = new Date().getHours();
-    if (hour >= 5 && hour < 8) return 'dawn';
-    if (hour >= 8 && hour < 18) return 'day';
-    if (hour >= 18 && hour < 20) return 'dusk';
+    const start = GAME_CONFIG.DAY_START_HOUR;
+    const end = GAME_CONFIG.DAY_END_HOUR;
+    if (hour >= start - 1 && hour < start) return 'dawn';
+    if (hour >= start && hour < end) return 'day';
+    if (hour >= end && hour < end + 2) return 'dusk';
     return 'night';
 }
 
@@ -758,9 +763,10 @@ function plantCrop(type) {
     emptySlot.plantedAt = Date.now();
     let timeMultiplier = 1;
     if (isNightTime()) {
-        timeMultiplier = 1.5;
+        timeMultiplier = GAME_CONFIG.NIGHT_GROWTH_MULTIPLIER;
     }
-    emptySlot.growTime = cropData.growTime * (season.cropGrowthMultiplier || 1) * timeMultiplier;
+    emptySlot.growTime =
+        cropData.growTime * (season.cropGrowthMultiplier || 1) * timeMultiplier;
     emptySlot.readyAt = Date.now() + emptySlot.growTime;
     emptySlot.isReady = false;
     

--- a/scripts.js
+++ b/scripts.js
@@ -170,6 +170,26 @@ function updateSeason() {
     }
 }
 
+function isNightTime() {
+    const hour = new Date().getHours();
+    return hour < 6 || hour >= 18;
+}
+
+function getTimeOfDay() {
+    const hour = new Date().getHours();
+    if (hour >= 5 && hour < 8) return 'dawn';
+    if (hour >= 8 && hour < 18) return 'day';
+    if (hour >= 18 && hour < 20) return 'dusk';
+    return 'night';
+}
+
+function updateLighting() {
+    const overlay = document.getElementById('weatherOverlay');
+    if (!overlay) return;
+    const time = getTimeOfDay();
+    overlay.className = `weather-overlay weather-${time}`;
+}
+
 // Crop unlock condition checking
 function checkCropUnlockCondition(crop) {
     if (!crop.unlockCondition) return true;
@@ -736,7 +756,11 @@ function plantCrop(type) {
     const season = getCurrentSeason();
     emptySlot.type = type;
     emptySlot.plantedAt = Date.now();
-    emptySlot.growTime = cropData.growTime * (season.cropGrowthMultiplier || 1);
+    let timeMultiplier = 1;
+    if (isNightTime()) {
+        timeMultiplier = 1.5;
+    }
+    emptySlot.growTime = cropData.growTime * (season.cropGrowthMultiplier || 1) * timeMultiplier;
     emptySlot.readyAt = Date.now() + emptySlot.growTime;
     emptySlot.isReady = false;
     
@@ -887,6 +911,8 @@ function nextDay() {
     showToast(`🌅 Day ${gameState.day} begins! Your cows have new moods!`, 'success');
 
     updateStatsChart();
+
+    updateLighting();
 
     if (navigator.vibrate) {
         navigator.vibrate([300, 100, 300]);
@@ -1665,6 +1691,9 @@ function initializeGame() {
     updateStatsChart();
     updateAchievements();
     updateSaveInfo();
+
+    updateLighting();
+    setInterval(updateLighting, 600000); // Refresh lighting every 10 minutes
     
     // Check achievements on startup (for achievements that might already be earned)
     checkAchievements();

--- a/styles.css
+++ b/styles.css
@@ -1652,3 +1652,21 @@ body {
 .debug-button-green {
     background: linear-gradient(145deg, #32CD32, #228B22);
 }
+
+/* Weather / Lighting Overlay */
+.weather-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 200;
+    mix-blend-mode: multiply;
+    transition: background-color 0.5s ease;
+}
+
+.weather-dawn { background: rgba(255, 200, 100, 0.3); }
+.weather-day { background: rgba(255, 255, 255, 0); }
+.weather-dusk { background: rgba(255, 120, 80, 0.3); }
+.weather-night { background: rgba(0, 0, 80, 0.4); }


### PR DESCRIPTION
## Summary
- overlay element for dynamic lighting
- lighting CSS styles for dawn/day/dusk/night
- functions to detect time of day and toggle overlay
- slow crop growth at night

## Testing
- `node -e "require('./scripts.js')"` *(fails: GAME_CONFIG not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68642a319bc0833198beacb3f93e4263