### PR TITLE
Display current time in game header

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ Modify the JSON files to add new cows, crops, shop items or rhythm patterns. Ref
 - Spend coins or milk on upgrades in the shop.
 - Unlock more content as you progress through the days.
 - Seasons rotate every 10 days, changing crop growth speed and cow mood.
+- The header displays the current local time so you know what part of the day the farm is themed for.
 
 The game automatically saves progress and works in modern browsers with JavaScript enabled.

--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@
       <div class="stat"> <span class="stat-value" id="day">1</span>
         <div class="stat-label">&#x1F4C5; Day</div>
       </div>
+      <div class="stat time-stat"> <span class="stat-value" id="timeDisplay"></span>
+        <div class="stat-label">&#x1F552; Time</div>
+      </div>
     </div>
     <div id="effectTimers" class="effect-timers"></div>
   </div>

--- a/scripts.js
+++ b/scripts.js
@@ -1897,7 +1897,8 @@ setInterval(renderEffectTimers, 1000);
 
 // Update time-of-day theme based on real-world time
 function updateTimeTheme() {
-    const hour = new Date().getHours();
+    const now = new Date();
+    const hour = now.getHours();
     let theme = 'day';
     if (hour >= 5 && hour < 8) {
         theme = 'dawn';
@@ -1911,8 +1912,13 @@ function updateTimeTheme() {
     const root = document.body;
     root.classList.remove('dawn', 'day', 'dusk', 'night');
     root.classList.add(theme);
+
+    const timeEl = document.getElementById('timeDisplay');
+    if (timeEl) {
+        timeEl.textContent = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
 }
 
-// Apply the theme immediately and update every hour
+// Apply the theme immediately and update every minute
 updateTimeTheme();
-setInterval(updateTimeTheme, 60 * 60 * 1000);
+setInterval(updateTimeTheme, 60 * 1000);

--- a/styles.css
+++ b/styles.css
@@ -51,7 +51,7 @@ body {
 
 .stats-bar {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(5, 1fr);
     gap: 5px;
     padding: 10px 0;
 }


### PR DESCRIPTION
## Summary
- add a time slot to the header
- widen stats grid to five columns
- update JS to refresh the local time every minute
- document the new header clock

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68642db634188331a1dcf1706ae48bd9