### PR TITLE
Add secret cow stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,9 @@
         <div class="stats-chart-container">
           <canvas id="statsChart"></canvas>
         </div>
+        <div class="save-info-text">
+          Secret Cows: <span id="secretCowCount" class="save-info-label"></span>
+        </div>
         <div class="achievements-container">
           <h3 class="section-title section-title-blue">&#x1F3C6; ACHIEVEMENTS &#x1F3C6;</h3>
           <div id="achievementsList"> 

--- a/scripts.js
+++ b/scripts.js
@@ -5,6 +5,7 @@ let rhythmPatterns = {};
 let achievementsData = {};
 let cowData = [];
 let secretCows = [];
+let totalSecretCows = 0;
 let statsChart;
 
 // Data loading system
@@ -31,6 +32,7 @@ async function loadGameData() {
         // Process cow data
         cowData = cowsData.cowData;
         secretCows = cowsData.secretCows;
+        totalSecretCows = secretCows.length;
 
         // Convert crops array to lookup object for backward compatibility
         cropTypes = {};
@@ -1668,6 +1670,11 @@ function updateDisplay() {
         } else {
             moodEl.textContent = '0';
         }
+    }
+
+    const secretCowEl = document.getElementById('secretCowCount');
+    if (secretCowEl) {
+        secretCowEl.textContent = `${gameState.stats.secretCowsUnlocked}/${totalSecretCows}`;
     }
 
     // → NEW: auto-unlock cows whose conditions are now met


### PR DESCRIPTION
## Summary
- show the number of secret cows in the Stats tab
- compute total secret cows from `cows.json`
- update display with secret cow progress

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686431f12ce883318a3b7a28347525f3