### PR TITLE
Add pest alert and reduce damage

### DIFF
--- a/config.js
+++ b/config.js
@@ -34,7 +34,8 @@ const GAME_CONFIG = {
         check_interval: 10000, // how often to attempt spawning pests
         spawn_chance: 0.1,    // chance per planted crop each check
         duration: 10000,      // time allowed to clear pests
-        yield_penalty: 0.5    // 50% yield reduction if not cleared
+        // Reduced penalty so pests are less destructive
+        yield_penalty: 0.25   // 25% yield reduction if not cleared
     },
 
     // Upgrade settings

--- a/scripts.js
+++ b/scripts.js
@@ -1011,6 +1011,10 @@ function spawnPest(index) {
     crop.pestPenalty = false;
     crop.pestExpiresAt = Date.now() + GAME_CONFIG.PESTS.duration;
     crop.pestTimerId = setTimeout(() => pestExpired(index), GAME_CONFIG.PESTS.duration);
+    showToast('🐛 Pests are attacking! Tap to clear them.', 'failure');
+    if (navigator.vibrate) {
+        navigator.vibrate(100);
+    }
     renderCrops();
 }
 


### PR DESCRIPTION
## Summary
- reduce crop yield penalty from pests
- alert players when pests attack

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6864323206008331b84f9341765b26c0