### PR TITLE
Add achievement effect icon display

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
       </div>
     </div>
     <div id="effectTimers" class="effect-timers"></div>
+    <div id="achievementEffects" class="achievement-effects"></div>
   </div>
   
   <!-- Tab Navigation -->

--- a/scripts.js
+++ b/scripts.js
@@ -6,6 +6,15 @@ let achievementsData = {};
 let cowData = [];
 let secretCows = [];
 let statsChart;
+const ACHIEVEMENT_EFFECT_ICONS = {
+    milk_boost_permanent: "🥛",
+    coin_boost_permanent: "💰",
+    crop_growth_boost: "🌱",
+    rhythm_tolerance_boost: "🎵",
+    happiness_aura: "😊",
+    perfectionist_aura: "🏆",
+    legend_status: "🌟"
+};
 
 // Data loading system
 async function loadGameData() {
@@ -1292,6 +1301,7 @@ function applyAchievementEffect(effectType) {
         default:
             console.log(`Unknown achievement effect: ${effectType}`);
     }
+    renderAchievementEffectIcons();
 }
 
 function showAchievementUnlock(achievement) {
@@ -1614,6 +1624,22 @@ function restartEffectTimers() {
     });
     renderEffectTimers();
 }
+function renderAchievementEffectIcons() {
+    const container = document.getElementById("achievementEffects");
+    if (!container) return;
+    container.innerHTML = "";
+    const effects = gameState.effects.achievements || {};
+    Object.keys(effects).forEach(key => {
+        if (!effects[key]) return;
+        const icon = ACHIEVEMENT_EFFECT_ICONS[key];
+        if (!icon) return;
+        const span = document.createElement("span");
+        span.className = "achievement-effect-icon";
+        span.textContent = icon;
+        container.appendChild(span);
+    });
+}
+
 
 // --- Meteor Shower Event System ---
 function maybeTriggerMeteorShower() {
@@ -1791,6 +1817,7 @@ function initializeGame() {
     }
 
     restartEffectTimers();
+    renderAchievementEffectIcons();
 
     // Apply any happiness decay since last session
     updateAllCowHappiness();

--- a/styles.css
+++ b/styles.css
@@ -103,6 +103,19 @@ body {
     color: #8B4513;
 }
 
+.achievement-effects {
+    display: flex;
+    justify-content: center;
+    gap: 4px;
+    padding-bottom: 6px;
+}
+
+.achievement-effect-icon {
+    width: 20px;
+    height: 20px;
+    font-size: 20px;
+}
+
 .main-content {
     flex: 1;
     overflow-y: auto;


### PR DESCRIPTION
## Summary
- show achievement effect icons in the header
- style the icons
- render active achievement effects when unlocked or loaded

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686431e5dd9c8331b541b31032f02696