### PR TITLE
Update header for time-of-day themes

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1992,6 +1992,12 @@ function updateTimeTheme() {
     root.classList.remove('dawn', 'day', 'dusk', 'night');
     root.classList.add(theme);
 
+    const header = document.querySelector('.game-header');
+    if (header) {
+        header.classList.remove('dawn', 'day', 'dusk', 'night');
+        header.classList.add(theme);
+    }
+
     const timeEl = document.getElementById('timeDisplay');
     if (timeEl) {
         timeEl.textContent = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });

--- a/styles.css
+++ b/styles.css
@@ -1720,3 +1720,20 @@ body.night {
     background: linear-gradient(135deg, #2C3E50 0%, #4B79A1 100%);
     color: #FFFFFF;
 }
+
+/* Header gradients for time-of-day themes */
+.game-header.dawn {
+    background: linear-gradient(135deg, #FFE5B4 0%, #FFD59E 100%);
+}
+
+.game-header.day {
+    background: linear-gradient(135deg, #E6A853 0%, #D4941E 100%);
+}
+
+.game-header.dusk {
+    background: linear-gradient(135deg, #FDB99B 0%, #CF8E80 100%);
+}
+
+.game-header.night {
+    background: linear-gradient(135deg, #2C3E50 0%, #4B79A1 100%);
+}


### PR DESCRIPTION
## Summary
- sync game header theme with time of day
- add CSS for `.game-header` dawn/day/dusk/night

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865ac03e778833182dc5a066f86fed0