### PR TITLE
Unlock Clover crop via Lucky Clover item

### DIFF
--- a/crops.json
+++ b/crops.json
@@ -188,6 +188,20 @@
       "description": "Legendary orchard treasure!"
     },
     {
+      "id": "clover",
+      "name": "Clover",
+      "emoji": "\uD83C\uDF40",
+      "cost": 80,
+      "value": 85,
+      "growTime": 65000,
+      "rarity": "rare",
+      "unlockCondition": {
+        "type": "upgrade",
+        "target": "lucky_clover"
+      },
+      "description": "Bring a bit of luck to your harvest!"
+    },
+    {
       "id": "cosmic_crop",
       "name": "Cosmic Crop",
       "emoji": "\u2728",

--- a/scripts.js
+++ b/scripts.js
@@ -196,6 +196,8 @@ function checkCropUnlockCondition(crop) {
             return gameState.stats.totalCoinsEarned >= condition.target;
         case 'perfectScores':
             return gameState.stats.totalPerfectScores >= condition.target;
+        case 'upgrade':
+            return gameState.upgrades[condition.target] > 0;
         default:
             return true;
     }


### PR DESCRIPTION
## Summary
- extend crop unlock conditions to support checking for purchased upgrades
- add new Clover crop gated behind buying Lucky Clover

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865ade36c9c833182a86b9922cd0b08