### PR TITLE
Move minigame close button inside result popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,6 @@
       <div class="mobile-controls">
         <button class="control-btn" id="tapBtn">&#x1F446;<br>TAP</button>
       </div>
-      <button class="close-minigame" onclick="closeMinigame()">&#x274C; CLOSE</button>
     </div>
   </div>
 </div>

--- a/minigame.js
+++ b/minigame.js
@@ -449,8 +449,8 @@ function showMinigameResult(message) {
     if (!popup) return;
 
     popup.innerHTML = `
-        <button class="close-result" onclick="closeResultPopup()">&#x274C;</button>
         <div class="result-text">${message}</div>
+        <button class="close-minigame" onclick="closeMinigame()">&#x274C; CLOSE</button>
     `;
     popup.style.display = 'block';
 }

--- a/styles.css
+++ b/styles.css
@@ -801,17 +801,6 @@ body {
     border: 3px solid #8B4513;
 }
 
-.close-result {
-    position: absolute;
-    top: 5px;
-    right: 5px;
-    background: transparent;
-    border: none;
-    color: #8B4513;
-    font-size: 1.2em;
-    cursor: pointer;
-    font-weight: bold;
-}
 
 .close-achievement {
     position: absolute;


### PR DESCRIPTION
## Summary
- remove standalone close button in the minigame footer
- place the close button inside the result popup
- drop unused `.close-result` CSS rules

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865b4a4b8648331b69ec7671e6f2551