### PR TITLE
Fix happiness timer reset when replaying cow

### DIFF
--- a/minigame.js
+++ b/minigame.js
@@ -413,7 +413,7 @@ function endMinigame() {
         gameState.stats.totalCoinsEarned += coinReward;
         cow.isHappy = true;
         cow.happinessLevel = Math.min(100, cow.happinessLevel + 20);
-        
+
     } else {
         gameState.stats.currentPerfectStreak = 0; // Reset streak on failure
         const coinLoss = Math.floor(Math.random() * 8) + 3;
@@ -423,6 +423,11 @@ function endMinigame() {
 
         resultMessage = `😤 ${cow.name} is not impressed!<br>-${coinLoss} coins.<br>Max Combo: ${currentMinigame.maxCombo}`;
         if (navigator.vibrate) navigator.vibrate(300);
+    }
+
+    // Synchronize mood stats and reset happiness timer
+    if (typeof refreshCowMood === 'function') {
+        refreshCowMood(cow);
     }
     
     updateDisplay();


### PR DESCRIPTION
## Summary
- ensure a cow's `lastHappinessUpdate` is refreshed whenever a minigame ends

## Testing
- `node -c minigame.js`
- `node -e "require('./minigame.js'); console.log('loaded');"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6865b5d5e97483319ac555c71dd12c16