### PR TITLE
Remove fixed layout to allow scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -13,21 +13,23 @@
 body {
     font-family: 'Montserrat', sans-serif;
     background: linear-gradient(135deg, #E6A853 0%, #D4941E 100%);
-    height: 100vh;
-    overflow: hidden;
-    position: fixed;
+    min-height: 100vh;
+    overflow-x: hidden;
+    overflow-y: auto;
+    position: static;
     width: 100%;
     touch-action: manipulation;
 }
 
 .mobile-container {
-    height: 100vh;
+    min-height: 100vh;
     display: flex;
     flex-direction: column;
     position: relative;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: visible;
     max-width: 100%;
-    margin: 0 auto
+    margin: 0 auto;
 }
 
 .game-header {
@@ -214,7 +216,6 @@ body {
 
 .main-content {
     flex: 1;
-    overflow-y: auto;
     padding: 0px;
     -webkit-overflow-scrolling: touch;
 }
@@ -622,12 +623,8 @@ body {
 
 /* Next Day button at the bottom */
 .next-day-bar {
-    position: fixed;
-    bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%);
+    margin: 20px auto;
     width: calc(100% - 40px);
-    z-index: 200;
 }
 
 .next-day-bar .action-btn {
@@ -1134,15 +1131,16 @@ body {
 
 /* Prevent iOS bounce scrolling but allow vertical scroll */
 html {
-    height: 100%;
-    overflow: hidden;
+    min-height: 100%;
+    overflow-x: hidden;
 }
 
 body {
-    height: 100vh;
-    width: 100vw;
-    overflow: hidden;
-    position: fixed;
+    min-height: 100vh;
+    width: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+    position: static;
     touch-action: pan-y;
 }
 
@@ -1150,17 +1148,11 @@ body {
 .main-content {
     -webkit-overflow-scrolling: touch;
     touch-action: pan-y;
-    height: calc(100vh - 120px);
-    overflow-y: auto;
-    overflow-x: hidden;
 }
 
 .tab-content {
     touch-action: pan-y;
-    max-height: calc(100vh - 200px);
-    overflow-y: auto;
-    /* Extra space so the fixed Next Day button doesn't cover the last items */
-    padding-bottom: 120px;
+    padding-bottom: 20px;
 }
 
 /* Enhanced visual effects */


### PR DESCRIPTION
## Summary
- remove many fixed/sticky styles so the body can scroll normally
- make main content and tab panes expand and scroll with the page
- keep overlays fixed but free the `next-day` button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865e4ff70508331a7b81cbc7f48bec1