### PR TITLE
Remove redundant HIT_COLORS constant

### DIFF
--- a/minigame.js
+++ b/minigame.js
@@ -18,13 +18,6 @@ const DEFAULT_HIT_COLORS = {
     miss: '#FF0000'
 };
 
-// Colors for hit feedback.
-const HIT_COLORS = {
-    perfect: '#00FF00',
-    good: '#FFFF00',
-    okay: '#FF8C00',
-    miss: '#FF0000'
-};
 
 function getHitColor(type) {
     if (rhythmPatterns.hitColors && rhythmPatterns.hitColors[type]) {
@@ -179,7 +172,6 @@ function spawnNote() {
         if (note.parentNode) {
             // Visual feedback for missing a note
             note.style.background = getHitColor('miss');
-            note.style.background = HIT_COLORS.miss;
             setTimeout(() => {
                 if (note.parentNode) note.parentNode.removeChild(note);
             }, 200);
@@ -221,13 +213,11 @@ function hitNote(note) {
         hitQuality = 'perfect';
         currentMinigame.combo++;
         note.style.background = getHitColor('perfect');
-        note.style.background = HIT_COLORS.perfect;
         if (navigator.vibrate) navigator.vibrate(50);
     } else if (distance < 80 * baseTolerance) {
         hitQuality = 'good';
         currentMinigame.combo++;
         note.style.background = getHitColor('good');
-        note.style.background = HIT_COLORS.good;
         if (navigator.vibrate) navigator.vibrate(30);
     } else if (distance < 120 * baseTolerance) {
         hitQuality = 'okay';
@@ -237,7 +227,6 @@ function hitNote(note) {
         currentMinigame.combo = 0;
         hitQuality = 'miss';
         note.style.background = getHitColor('miss');
-        note.style.background = HIT_COLORS.miss;
         points = 0;
     }
     


### PR DESCRIPTION
## Summary
- remove the `HIT_COLORS` constant from `minigame.js`
- use `getHitColor()` when coloring notes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6865eaaa3d2883319cd1b7b45fd566d2