### PR TITLE
Fix timed effect duration

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -415,9 +415,15 @@ function buyUpgrade(itemId) {
 // Flexible effect application system
 function applyUpgradeEffects(item) {
     if (!item.effects) return;
-    
+
+    const duration = item.effects.duration
+        ? item.effects.duration
+        : (item.effects.duration_minutes
+            ? item.effects.duration_minutes * 60000
+            : 0);
+
     Object.keys(item.effects).forEach(effectType => {
-        if (effectType === 'duration') return;
+        if (effectType === 'duration' || effectType === 'duration_minutes') return;
         const effectValue = item.effects[effectType];
         
         switch (effectType) {
@@ -513,8 +519,8 @@ function applyUpgradeEffects(item) {
                 console.log(`Unknown effect type: ${effectType}`);
         }
 
-        if (item.effects.duration) {
-            startTimedEffect(item, effectType, effectValue, item.effects.duration);
+        if (duration) {
+            startTimedEffect(item, effectType, effectValue, duration);
         }
     });
 }


### PR DESCRIPTION
## Summary
- convert `duration_minutes` to milliseconds when applying upgrade effects
- start timed effects with the converted duration so they expire correctly

## Testing
- `node --check scripts.js`

------
https://chatgpt.com/codex/tasks/task_e_6865ea9d3d348331adbceff59c335ee5