### PR TITLE
Add progress bar score display

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,15 +149,17 @@
       <p class="minigame-instructions" id="minigameInstructions">Get ready to play!</p>
       <div class="countdown-clock" id="countdownClock">15</div>
     </div>
-    <div class="rhythm-game">
-      <div class="score-area container">
-        <div class="score-display">Score: <span id="currentScore">0</span></div>
-        <div class="score-display">Target: <span id="targetScore">100</span></div>
+      <div class="rhythm-game">
+        <div class="score-area container">
+          <div class="score-bar">
+            <div class="score-fill" id="scoreFill"></div>
+            <div class="score-numbers"><span id="currentScore">0</span>/<span id="targetScore">100</span></div>
+          </div>
+        </div>
+        <div class="rhythm-bar" id="rhythmBar">
+          <div class="rhythm-marker"></div>
+        </div>
       </div>
-      <div class="rhythm-bar" id="rhythmBar">
-        <div class="rhythm-marker"></div>
-      </div>
-    </div>
     <div class="minigame-footer">
       <div class="mobile-controls">
         <button class="control-btn" id="tapBtn">&#x1F446;<br>TAP</button>

--- a/minigame.js
+++ b/minigame.js
@@ -55,6 +55,8 @@ function startRhythmGame(cowIndex) {
 
     document.getElementById('currentScore').textContent = '0';
     document.getElementById('targetScore').textContent = currentMinigame.target;
+    const scoreFill = document.getElementById('scoreFill');
+    if (scoreFill) scoreFill.style.width = '0%';
     const countdownEl = document.getElementById('countdownClock');
     if (countdownEl) countdownEl.textContent = currentMinigame.timeLeft;
 
@@ -191,6 +193,8 @@ function spawnNote() {
 // Enhanced hit detection with new tolerance system
 function hitNote(note) {
     if (!note) return;
+
+    const scoreFill = document.getElementById('scoreFill');
     
     const noteRect = note.getBoundingClientRect();
     const marker = document.querySelector('.rhythm-marker');
@@ -253,6 +257,10 @@ function hitNote(note) {
     // Ensure displayed score never shows decimals
     const displayScore = Math.floor(currentMinigame.score);
     document.getElementById('currentScore').textContent = displayScore;
+    if (scoreFill) {
+        const progress = Math.min(currentMinigame.score / currentMinigame.target, 1) * 100;
+        scoreFill.style.width = progress + '%';
+    }
 
     if (points > 0) {
         showFloatingText(`+${points}!`, noteRect.left, noteRect.top);

--- a/styles.css
+++ b/styles.css
@@ -837,6 +837,35 @@ body {
     margin: 0 5px;
 }
 
+/* Progress bar for the rhythm game score */
+.score-bar {
+    position: relative;
+    width: 100%;
+    height: 20px;
+    background: #e0e0e0;
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.score-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0;
+    background: linear-gradient(90deg, #4ECDC4, #FF6B6B);
+    transition: width 0.3s ease;
+}
+
+.score-numbers {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #fff;
+    font-weight: bold;
+}
+
 
 .mobile-controls {
     display: grid;


### PR DESCRIPTION
## Summary
- use a bar for minigame score
- style the score bar and animated fill
- update minigame logic to adjust bar as points are earned

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867144e40c883318d77e8d77ca5a945