### PR TITLE
Add tab transition class

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -548,10 +548,16 @@ function switchTab(tabName, evt) {
     // Update tab buttons
     document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));
     evt.target.classList.add('active');
-    
+
     // Update tab content
-    document.querySelectorAll('.tab-content').forEach(content => content.classList.remove('active'));
-    document.getElementById(tabName + 'Tab').classList.add('active');
+    document.querySelectorAll('.tab-content').forEach(content => {
+        content.classList.remove('active', 'tab-transition');
+    });
+    const newTab = document.getElementById(tabName + 'Tab');
+    newTab.classList.add('active');
+    // Force reflow to restart animation
+    void newTab.offsetWidth;
+    newTab.classList.add('tab-transition');
 
     if (tabName === 'stats') {
         updateStatsChart();

--- a/styles.css
+++ b/styles.css
@@ -259,6 +259,11 @@ body {
     animation: fadeIn 0.3s ease;
 }
 
+/* Added for smoother tab switching */
+.tab-transition {
+    animation: tabFadeSlide 0.3s ease;
+}
+
 .tab-content-wrapper { width:96%; margin:0 auto;}
 .tab-content.active {
     display: block;
@@ -272,6 +277,18 @@ body {
     to {
         opacity: 1;
         transform: translateY(0);
+    }
+}
+
+/* Animation for tab transitions */
+@keyframes tabFadeSlide {
+    from {
+        opacity: 0;
+        transform: translateX(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
     }
 }
 


### PR DESCRIPTION
## Summary
- play tab transition animations when switching tabs
- add slide/fade animation CSS and apply it in `switchTab`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68673357a6c48331a341cb83a9056634