### PR TITLE
Add icons to harvest and next day buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 <meta name="mobile-web-app-capable" content="yes">
 <title>Moo-d Swings: Farmyard Follies</title>
 <link rel="stylesheet" href="styles.css?v=moo3.5">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 <body>
 <div class="mobile-container"> 
@@ -89,7 +90,7 @@
           </div>
         </div>
         <div class="action-buttons">
-          <button class="action-btn harvest" onclick="harvestAll()">&#x1F33E; HARVEST ALL</button>
+          <button class="action-btn harvest" onclick="harvestAll()"><i class="fa-solid fa-seedling btn-icon"></i>Harvest All</button>
         </div>
       </div>
       
@@ -136,7 +137,7 @@
       </div>
     </div>
     <div class="next-day-bar">
-      <button class="action-btn" onclick="nextDay()">&#x2600;&#xFE0F; NEXT DAY</button>
+      <button class="action-btn" onclick="nextDay()"><i class="fa-solid fa-sun btn-icon"></i>Next Day</button>
     </div>
   </div>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -608,6 +608,12 @@ body {
     box-shadow: 0 4px 15px rgba(255,107,107,0.3);
 }
 
+.action-btn .btn-icon {
+    margin-right: 6px;
+    font-size: 1.2em;
+    vertical-align: middle;
+}
+
 .action-btn:hover {
     transform: translateY(-2px);
     box-shadow: 0 6px 20px rgba(255,107,107,0.4);


### PR DESCRIPTION
## Summary
- include Font Awesome for icons
- add icons to `Harvest All` and `Next Day` buttons
- style `.action-btn` icons for alignment

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6867335647d883318f54949b4c4e8537