### PR TITLE
Add day countdown timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,7 @@
     </div>
     <div class="next-day-bar">
       <button class="action-btn" onclick="nextDay()">&#x2600;&#xFE0F; NEXT DAY</button>
+      <span id="nextDayCountdown"></span>
     </div>
   </div>
 </div>

--- a/scripts.js
+++ b/scripts.js
@@ -7,6 +7,8 @@ let cowData = [];
 let secretCows = [];
 let statsChart;
 let autoWaterTimerId = null;
+let dayCountdownTimerId = null;
+let dayCountdownRemaining = 0;
 
 // Data loading system
 async function loadGameData() {
@@ -997,6 +999,7 @@ function harvestAll() {
 }
 
 function nextDay() {
+    if (dayCountdownTimerId) clearInterval(dayCountdownTimerId);
     // Record the day's totals before resetting
     gameState.dailyMilkTotals.push(gameState.dailyStats.milkProduced);
     gameState.dailyCoinTotals.push(gameState.dailyStats.coinsEarned);
@@ -1040,6 +1043,7 @@ function nextDay() {
     if (navigator.vibrate) {
         navigator.vibrate([300, 100, 300]);
     }
+    startDayCountdown();
 }
 
 function updateBulletin() {
@@ -1173,6 +1177,21 @@ function startAutoWater() {
     if (!gameState.effects.autoWater) return;
     autoWaterTimerId = setInterval(autoWaterCrops, 3600000); // hourly
     autoWaterCrops();
+}
+
+function startDayCountdown(seconds = 60) {
+    clearInterval(dayCountdownTimerId);
+    dayCountdownRemaining = seconds;
+    const el = document.getElementById('nextDayCountdown');
+    if (el) el.textContent = `${dayCountdownRemaining}s`;
+    dayCountdownTimerId = setInterval(() => {
+        dayCountdownRemaining--;
+        if (el) el.textContent = `${Math.max(dayCountdownRemaining, 0)}s`;
+        if (dayCountdownRemaining <= 0) {
+            clearInterval(dayCountdownTimerId);
+            nextDay();
+        }
+    }, 1000);
 }
 
 function convertMilkToCoins() {
@@ -2054,6 +2073,7 @@ function showAchievement(title, description) {
 loadGameData().then(() => {
     initializeGame();
     startPestChecks();
+    startDayCountdown();
 });
 
 

--- a/styles.css
+++ b/styles.css
@@ -629,6 +629,17 @@ body {
 
 .next-day-bar .action-btn {
     width: 100%;
+    font-size: 1.3em;
+    padding: 20px;
+}
+
+#nextDayCountdown {
+    display: block;
+    text-align: center;
+    font-size: 1.1em;
+    font-weight: bold;
+    margin-top: 8px;
+    color: #333;
 }
 
 


### PR DESCRIPTION
## Summary
- add countdown span to index.html for next day
- implement `startDayCountdown` timer in game script
- restart timer after every day
- enlarge Next Day button and style countdown

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6867334b02a4833190d815ee3507c20d