### PR TITLE
Add farm map rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
         <div class="action-buttons">
           <button class="action-btn harvest" onclick="harvestAll()">&#x1F33E; HARVEST ALL</button>
         </div>
+        <canvas id="farmMap"></canvas>
       </div>
       
       <!-- Shop Tab -->

--- a/scripts.js
+++ b/scripts.js
@@ -701,6 +701,8 @@ function renderCows() {
         `;
         grid.appendChild(cowCard);
     });
+
+    renderFarmMap();
 }
 
 // Reduce each cow's happiness over time
@@ -818,6 +820,8 @@ function renderCrops() {
 
         grid.appendChild(cropSlot);
     });
+
+    renderFarmMap();
 }
 
 function handleCropClick(index) {
@@ -1233,6 +1237,56 @@ function updateStatsChart() {
         statsChart.data.datasets[1].data = gameState.dailyCoinTotals;
         statsChart.update();
     }
+}
+
+function renderFarmMap() {
+    const canvas = document.getElementById('farmMap');
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    const width = canvas.clientWidth;
+    const height = canvas.clientHeight;
+    canvas.width = width;
+    canvas.height = height;
+
+    ctx.clearRect(0, 0, width, height);
+
+    const cols = 4;
+    const rows = 3;
+    const padding = 8;
+    const cellW = (width - padding * 2) / cols;
+    const cellH = (height - padding * 2) / rows;
+
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            const x = padding + c * cellW;
+            const y = padding + r * cellH;
+            ctx.fillStyle = '#A0522D';
+            ctx.fillRect(x, y, cellW - 2, cellH - 2);
+            ctx.strokeStyle = '#8B4513';
+            ctx.strokeRect(x, y, cellW - 2, cellH - 2);
+
+            const index = r * cols + c;
+            const crop = gameState.crops[index];
+            if (crop && crop.type) {
+                const emoji = crop.isReady ? cropTypes[crop.type].emoji : '🌱';
+                ctx.font = Math.floor(Math.min(cellW, cellH) * 0.6) + 'px serif';
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'middle';
+                ctx.fillText(emoji, x + cellW / 2, y + cellH / 2);
+            }
+        }
+    }
+
+    const cowSpacing = width / (gameState.cows.length + 1);
+    ctx.font = Math.floor(cellH * 0.7) + 'px serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    gameState.cows.forEach((cow, i) => {
+        const x = cowSpacing * (i + 1);
+        const y = height - padding - cellH * 0.3;
+        ctx.fillText(cow.emoji, x, y);
+    });
 }
 
 // FIXED: Combined unlock check function that handles both regular and secret cows

--- a/styles.css
+++ b/styles.css
@@ -1860,6 +1860,15 @@ body {
     max-height: 200px;
 }
 
+#farmMap {
+    width: 100%;
+    max-height: 200px;
+    border: 2px solid #8B4513;
+    border-radius: 10px;
+    background: #fffaf0;
+    margin-top: 10px;
+}
+
 .achievements-container {
     background: linear-gradient(145deg, #E6F3FF, #F0F8FF);
     border-radius: 12px;


### PR DESCRIPTION
## Summary
- add farm map canvas to Farm tab
- draw crop plots and cows on new map
- trigger map redraw whenever crops or cows update
- style the farm map

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686733538838833189679cf8c8ca522b