### PR TITLE
Add icon support for effect timers

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1684,6 +1684,7 @@ function startTimedEffect(item, effectType, value, duration) {
     gameState.activeEffects.push({
         id: effectId,
         itemName: item.name,
+        icon: item.icon,
         effectType,
         value,
         expiresAt,
@@ -1738,7 +1739,14 @@ function renderEffectTimers() {
         }
         const div = document.createElement('div');
         div.className = 'effect-timer';
-        div.textContent = `${effect.itemName} ${Math.ceil(remaining / 1000)}s`;
+
+        const iconEl = document.createElement('img');
+        iconEl.className = 'effect-icon';
+        if (effect.icon) iconEl.dataset.icon = effect.icon;
+        iconEl.alt = effect.itemName;
+        div.appendChild(iconEl);
+
+        div.appendChild(document.createTextNode(` ${effect.itemName} ${Math.ceil(remaining / 1000)}s`));
         container.appendChild(div);
     });
 }

--- a/styles.css
+++ b/styles.css
@@ -195,6 +195,19 @@ body {
     animation: pulse 2s infinite;
 }
 
+.effect-icon {
+    width: 1em;
+    height: 1em;
+    margin-right: 4px;
+    vertical-align: middle;
+    display: inline-block;
+}
+
+.effect-icon::before {
+    content: attr(data-icon);
+    font-size: 1em;
+}
+
 @keyframes shimmer {
     0%, 100% { filter: brightness(1); }
     50% { filter: brightness(1.2); }


### PR DESCRIPTION
## Summary
- include `icon` when starting timed effects
- render effect icons beside timer text
- style icons in effect list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68673353e6fc83318f405c328959ea1c