### PR TITLE
Improve minigame countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,13 @@
     <div class="minigame-header">
       <h2 class="minigame-title" id="minigameTitle">Cow Challenge</h2>
       <p class="minigame-instructions" id="minigameInstructions">Get ready to play!</p>
-      <div class="countdown-clock" id="countdownClock">15</div>
+      <div class="countdown-wrapper">
+        <svg class="countdown-ring" width="70" height="70">
+          <circle class="ring-bg" cx="35" cy="35" r="32"></circle>
+          <circle class="ring-progress" id="countdownRing" cx="35" cy="35" r="32"></circle>
+        </svg>
+        <div class="countdown-clock" id="countdownClock">15</div>
+      </div>
     </div>
       <div class="rhythm-game">
         <div class="score-area container">

--- a/minigame.js
+++ b/minigame.js
@@ -1,13 +1,16 @@
+const COUNTDOWN_TOTAL = 15;
+
 let currentMinigame = {
     cowIndex: -1,
     score: 0,
     target: 100,
     noteInterval: null,
     countdownInterval: null,
-    timeLeft: 15,
+    timeLeft: COUNTDOWN_TOTAL,
     gameActive: false,
     combo: 0,
-    maxCombo: 0
+    maxCombo: 0,
+    ringCircumference: 0
 };
 
 // Default colors for hit feedback. These may be overridden by rhythmPatterns.hitColors
@@ -42,9 +45,11 @@ function getRandomGameType() {
 
 // Reset the countdown display and internal timer
 function resetMinigameTimer() {
-    currentMinigame.timeLeft = 15;
+    currentMinigame.timeLeft = COUNTDOWN_TOTAL;
     const countdownEl = document.getElementById('countdownClock');
+    const ring = document.getElementById('countdownRing');
     if (countdownEl) countdownEl.textContent = currentMinigame.timeLeft;
+    if (ring) ring.style.strokeDashoffset = 0;
 }
 
 function startRhythmGame(cowIndex) {
@@ -65,6 +70,13 @@ function startRhythmGame(cowIndex) {
     const scoreFill = document.getElementById('scoreFill');
     if (scoreFill) scoreFill.style.width = '0%';
     const countdownEl = document.getElementById('countdownClock');
+    const countdownRing = document.getElementById('countdownRing');
+    if (countdownRing) {
+        const radius = countdownRing.r.baseVal.value;
+        currentMinigame.ringCircumference = 2 * Math.PI * radius;
+        countdownRing.style.strokeDasharray = currentMinigame.ringCircumference;
+        countdownRing.style.strokeDashoffset = 0;
+    }
 
     const speed = getGameSpeed(cow.currentGameType || cow.gameType);
 
@@ -74,6 +86,10 @@ function startRhythmGame(cowIndex) {
     currentMinigame.countdownInterval = setInterval(() => {
         currentMinigame.timeLeft--;
         if (countdownEl) countdownEl.textContent = Math.max(0, currentMinigame.timeLeft);
+        if (countdownRing) {
+            const offset = currentMinigame.ringCircumference * (1 - currentMinigame.timeLeft / COUNTDOWN_TOTAL);
+            countdownRing.style.strokeDashoffset = offset;
+        }
         if (currentMinigame.timeLeft <= 0) {
             clearInterval(currentMinigame.countdownInterval);
         }
@@ -89,7 +105,7 @@ function startRhythmGame(cowIndex) {
         if (currentMinigame.gameActive) {
             endMinigame();
         }
-    }, 15000);
+    }, COUNTDOWN_TOTAL * 1000);
 }
 
 // Enhanced speed calculation using pattern data and effects

--- a/styles.css
+++ b/styles.css
@@ -737,6 +737,7 @@ body {
 }
 
 .minigame-header {
+    position: relative;
     text-align: center;
     margin-bottom: 20px;
 }
@@ -757,15 +758,46 @@ body {
 }
 
 .countdown-clock {
-    font-size: 1.2em;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 2em;
     font-weight: 800;
     color: #8B4513;
-    background: #FFF8DC;
-    border: 2px solid #8B4513;
-    border-radius: 10px;
-    padding: 5px 10px;
-    display: inline-block;
-    margin-top: 5px;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+
+.countdown-wrapper {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: 70px;
+    height: 70px;
+}
+
+.countdown-ring {
+    width: 100%;
+    height: 100%;
+    transform: rotate(-90deg);
+}
+
+.ring-bg {
+    fill: none;
+    stroke: #e0e0e0;
+    stroke-width: 6;
+}
+
+.ring-progress {
+    fill: none;
+    stroke: #8B4513;
+    stroke-width: 6;
+    stroke-dasharray: 201;
+    stroke-dashoffset: 0;
+    transition: stroke-dashoffset 1s linear;
 }
 
 .rhythm-game {


### PR DESCRIPTION
## Summary
- add a countdown wrapper with SVG progress circle
- enlarge countdown clock and position it
- keep timer updating and control progress ring in JS

## Testing
- `node -c minigame.js`
- `node -c scripts.js`
- `node -c config.js`


------
https://chatgpt.com/codex/tasks/task_e_686733521260833183209ec92381a649