### PR TITLE
Add shared grid container

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
     <div class="tab-content-wrapper"> 
       <!-- Cows Tab -->
       <div id="cowsTab" class="tab-content active">
-        <div class="cows-grid" id="cowsGrid"> 
+        <div class="cows-grid grid-container" id="cowsGrid">
           <!-- Cows will be generated here --> 
         </div>
       </div>
@@ -81,7 +81,7 @@
       <div id="farmTab" class="tab-content">
         <div class="crops-section">
           <h3 class="section-title section-title-brown">&#x1F33E; CROP FIELDS &#x1F33E;</h3>
-          <div class="crops-grid" id="cropsGrid"> 
+          <div class="crops-grid grid-container" id="cropsGrid">
             <!-- Crops will be generated here --> 
           </div>
           <div class="plant-controls">

--- a/styles.css
+++ b/styles.css
@@ -275,11 +275,13 @@ body {
     }
 }
 
-.cows-grid {
+
+.grid-container {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 2px;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    gap: 8px;
 }
+
 
 .cow-card {
     background: linear-gradient(145deg, #FFF8DC, #F5DEB3);
@@ -373,9 +375,6 @@ body {
 }
 
 .crops-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 8px;
     margin-bottom: 15px;
     background: linear-gradient(145deg, #8FBC8F, #90EE90);
     border-radius: 15px;
@@ -1194,20 +1193,14 @@ body {
     .secondary-stats {
         /* grid-template-columns: 1fr; */
     }
-    .cows-grid {
-        grid-template-columns: repeat(2, 1fr);
-    }
-    .crops-grid {
-        grid-template-columns: repeat(3, 1fr);
+    .grid-container {
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
     }
 }
 
 @media (min-width: 768px) {
-    .cows-grid {
-        grid-template-columns: repeat(3, 1fr);
-    }
-    .crops-grid {
-        grid-template-columns: repeat(6, 1fr);
+    .grid-container {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     }
 }
 


### PR DESCRIPTION
## Summary
- add generic `.grid-container` class with columns and gap
- remove old grid rules from `.cows-grid` and `.crops-grid`
- use `grid-container` class in index
- unify responsive grid styles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68673351a52c8331bc3ac0ae49d8317a