### PR TITLE
Add day timer

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,6 +6,8 @@ const GAME_CONFIG = {
     STARTING_COINS: 100,
     STARTING_MILK: 0,
     STARTING_DAY: 1,
+    // Duration of a single day in seconds
+    DAY_DURATION: 60,
 
     // Season settings
     SEASON_LENGTH: 10,

--- a/index.html
+++ b/index.html
@@ -137,6 +137,7 @@
     </div>
     <div class="next-day-bar">
       <button class="action-btn" onclick="nextDay()">&#x2600;&#xFE0F; NEXT DAY</button>
+      <span id="dayTimer" class="day-timer"></span>
     </div>
   </div>
 </div>

--- a/scripts.js
+++ b/scripts.js
@@ -7,6 +7,8 @@ let cowData = [];
 let secretCows = [];
 let statsChart;
 let autoWaterTimerId = null;
+let dayTimerIntervalId = null;
+let dayTimeRemaining = GAME_CONFIG.DAY_DURATION;
 
 // Data loading system
 async function loadGameData() {
@@ -1001,6 +1003,7 @@ function nextDay() {
     gameState.dailyMilkTotals.push(gameState.dailyStats.milkProduced);
     gameState.dailyCoinTotals.push(gameState.dailyStats.coinsEarned);
     gameState.day++;
+    startDayTimer();
     updateSeason();
     updateWeather();
     gameState.dailyStats = {
@@ -1188,6 +1191,28 @@ function convertMilkToCoins() {
     gameState.stats.totalCoinsEarned += coins;
     showToast(`Processed milk into ${Math.floor(coins)} coins!`, 'success');
     updateDisplay();
+}
+
+function updateDayTimerDisplay() {
+    const timerEl = document.getElementById('dayTimer');
+    if (timerEl) {
+        timerEl.textContent = `${dayTimeRemaining}s`;
+    }
+}
+
+function startDayTimer() {
+    if (dayTimerIntervalId) clearInterval(dayTimerIntervalId);
+    dayTimeRemaining = GAME_CONFIG.DAY_DURATION;
+    updateDayTimerDisplay();
+    dayTimerIntervalId = setInterval(() => {
+        dayTimeRemaining--;
+        if (dayTimeRemaining <= 0) {
+            clearInterval(dayTimerIntervalId);
+            dayTimerIntervalId = null;
+            nextDay();
+        }
+        updateDayTimerDisplay();
+    }, 1000);
 }
 
 function updateStatsChart() {
@@ -2032,6 +2057,8 @@ function initializeGame() {
     // Check for meteor showers at night
     maybeTriggerMeteorShower();
     setInterval(maybeTriggerMeteorShower, 60000);
+
+    startDayTimer();
 
     console.log('Game initialized with data-driven systems and achievements!');
 }

--- a/styles.css
+++ b/styles.css
@@ -631,6 +631,13 @@ body {
     width: 100%;
 }
 
+.day-timer {
+    margin-left: 10px;
+    font-weight: bold;
+    color: #8B4513;
+    white-space: nowrap;
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- configure day duration in `config.js`
- display an automatic day countdown beside the Next Day button
- restart a new timer after each day change

## Testing
- `node --check scripts.js`
- `node --check config.js`

------
https://chatgpt.com/codex/tasks/task_e_68673350f63c83319fccb27035e966e3