### PR TITLE
Add new achievement badge

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -555,6 +555,8 @@ function switchTab(tabName, evt) {
 
     if (tabName === 'stats') {
         updateStatsChart();
+        updateAchievements();
+        clearNewAchievementFlags();
     }
     
     // Reset scroll position for new tab
@@ -1357,6 +1359,7 @@ function checkAchievements() {
         // Check if condition is met
         if (checkAchievementCondition(achievement)) {
             gameState.achievements.push(achievement.id);
+            achievement.new = true; // mark as newly unlocked
             newAchievements.push(achievement);
             awardAchievement(achievement);
         }
@@ -1612,7 +1615,7 @@ function updateAchievements() {
                 <div class="achievement-item achievement-item-${rarity}${earned ? '' : ' achievement-item-locked'}">
                     <div class="achievement-item-icon">${achievement.icon}</div>
                     <div class="achievement-item-info">
-                        <div class="achievement-item-name">${achievement.name}</div>
+                        <div class="achievement-item-name">${achievement.name}${achievement.new ? ' <span class="new-badge">NEW</span>' : ''}</div>
                         <div class="achievement-item-desc">${achievement.description}</div>
                         <div class="achievement-item-reward">${formatAchievementReward(achievement.reward)}</div>
                         <div class="achievement-item-progress">
@@ -1629,6 +1632,15 @@ function updateAchievements() {
     });
 
     achievementsList.innerHTML = html;
+}
+
+function clearNewAchievementFlags() {
+    if (!achievementsData.achievements) return;
+    achievementsData.achievements.forEach(a => {
+        if (a.new) {
+            delete a.new;
+        }
+    });
 }
 
 // Enhanced rhythm game instructions using pattern data

--- a/styles.css
+++ b/styles.css
@@ -1678,6 +1678,15 @@ body {
     font-size: 0.9em;
 }
 
+.new-badge {
+    background: #FFD700;
+    color: #000;
+    font-size: 0.65em;
+    padding: 2px 4px;
+    border-radius: 4px;
+    margin-left: 4px;
+}
+
 .achievement-item-desc {
     font-size: 0.75em;
     color: #666;


### PR DESCRIPTION
## Summary
- mark newly unlocked achievements with a `new` flag
- show a **NEW** badge in the achievements list
- add styling for `.new-badge`
- clear the badge after visiting the stats tab

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6867335005d08331a782dd5c0acd0ad1