### PR TITLE
Add persistent active effects panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,7 @@
 <div class="meteor-overlay" id="meteorShowerOverlay"></div>
 <div class="rain-overlay" id="rainOverlay"></div>
 <div class="firefly-overlay" id="fireflyOverlay"></div>
+<div id="activeEffectsPanel" class="active-effects-panel"></div>
 <audio id="meteorSound" src="sounds/meteor.mp3" preload="auto"></audio>
 
 <script src="config.js?v=moo3.8"></script>

--- a/scripts.js
+++ b/scripts.js
@@ -1684,6 +1684,7 @@ function startTimedEffect(item, effectType, value, duration) {
     gameState.activeEffects.push({
         id: effectId,
         itemName: item.name,
+        icon: item.icon || '',
         effectType,
         value,
         expiresAt,
@@ -1726,7 +1727,7 @@ function removeTimedEffect(effectId) {
 }
 
 function renderEffectTimers() {
-    const container = document.getElementById('effectTimers');
+    const container = document.getElementById('activeEffectsPanel') || document.getElementById('effectTimers');
     if (!container) return;
     const now = Date.now();
     container.innerHTML = '';
@@ -1738,7 +1739,7 @@ function renderEffectTimers() {
         }
         const div = document.createElement('div');
         div.className = 'effect-timer';
-        div.textContent = `${effect.itemName} ${Math.ceil(remaining / 1000)}s`;
+        div.textContent = `${effect.icon ? effect.icon + ' ' : ''}${effect.itemName} ${Math.ceil(remaining / 1000)}s`;
         container.appendChild(div);
     });
 }

--- a/styles.css
+++ b/styles.css
@@ -195,6 +195,18 @@ body {
     animation: pulse 2s infinite;
 }
 
+/* Floating panel showing active timed effects */
+#activeEffectsPanel {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 6px;
+    z-index: 1050;
+}
+
 @keyframes shimmer {
     0%, 100% { filter: brightness(1); }
     50% { filter: brightness(1.2); }


### PR DESCRIPTION
## Summary
- create a floating panel to show active effects while playing
- include each effect's icon and remaining time in the panel
- ensure the panel stays fixed in view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867334ea3208331bee785021ee30fce