### PR TITLE
Fix cows grid layout to 2 columns

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2091,3 +2091,8 @@ body.season-winter {
         animation: none;
     }
 }
+
+/* Ensure consistent two-column layout for cow cards */
+.cows-grid {
+    grid-template-columns: repeat(2, 1fr);
+}


### PR DESCRIPTION
## Summary
- ensure cows grid always uses a two-column layout in CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68673aacd8548331951082deb97bbf64