### PR TITLE
Add mood sorting feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ Certain shop upgrades provide automation:
 - **Pest Control** keeps pests away from your fields for five minutes. You can stock up to 100 of them.
 
 The game automatically saves progress and works in modern browsers with JavaScript enabled.
+
+## Mood Ranking
+Use the **Sort by Mood** button on the Cows tab to display cows from saddest to happiest.
+You can also call `getCowMoodRanking()` in the browser console to retrieve the current order programmatically.

--- a/index.html
+++ b/index.html
@@ -73,8 +73,9 @@
     <div class="tab-content-wrapper"> 
       <!-- Cows Tab -->
       <div id="cowsTab" class="tab-content active">
+        <button class="sort-btn" onclick="showCowMoodRanking()">Sort by Mood</button>
         <div class="cows-grid grid-container" id="cowsGrid">
-          <!-- Cows will be generated here --> 
+          <!-- Cows will be generated here -->
         </div>
       </div>
       

--- a/scripts.js
+++ b/scripts.js
@@ -826,6 +826,18 @@ function updateAllCowHappiness() {
     renderCows();
 }
 
+// Return cows sorted from saddest to happiest
+function getCowMoodRanking() {
+    return [...gameState.cows].sort((a, b) => a.moodValue - b.moodValue);
+}
+
+// Display the current cow mood order in a toast message
+function showCowMoodRanking() {
+    const ranking = getCowMoodRanking();
+    const names = ranking.map(c => c.name).join(' -> ');
+    showToast(`Mood order: ${names}`, 'info');
+}
+
 function applyCowbellThreshold() {
     if (!gameState.upgrades || !gameState.upgrades.cowbell) return;
     const cowbellCfg = GAME_CONFIG.UPGRADES && GAME_CONFIG.UPGRADES.cowbell;

--- a/styles.css
+++ b/styles.css
@@ -400,6 +400,31 @@ body {
     box-shadow: none;
 }
 
+.sort-btn {
+    background: linear-gradient(145deg, #6A5ACD, #836FFF);
+    color: white;
+    border: none;
+    padding: 8px 12px;
+    border-radius: 15px;
+    font-family: 'Montserrat', sans-serif;
+    font-weight: bold;
+    font-size: 0.8em;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 3px 10px rgba(106,90,205,0.3);
+    margin-bottom: 10px;
+}
+
+.sort-btn:hover {
+    background: linear-gradient(145deg, #483D8B, #6A5ACD);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(106,90,205,0.4);
+}
+
+.sort-btn:active {
+    transform: scale(0.95);
+}
+
 .crops-section {
     background: rgba(255,255,255,0.9);
     border-radius: 20px;


### PR DESCRIPTION
## Summary
- add `getCowMoodRanking()` and `showCowMoodRanking()` helpers
- add Sort by Mood button in the cow tab
- style new button
- document mood ranking feature in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68680b0e1228833182baa0c79cc6dbb1