### PR TITLE
Add crop reward tooltip

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -337,9 +337,10 @@ function generateCropButtons() {
     container.innerHTML = availableCrops.map(cropId => {
         const crop = cropTypes[cropId];
         const rarityClass = crop.rarity ? `crop-${crop.rarity}` : '';
-        
+        const titleText = `${crop.description ? crop.description + ' - ' : ''}Reward: ${crop.value} coins`;
+
         return `
-            <button class="plant-btn ${rarityClass}" onclick="plantCrop('${cropId}')" title="${crop.description || ''}">
+            <button class="plant-btn ${rarityClass}" onclick="plantCrop('${cropId}')" title="${titleText}">
                 ${crop.emoji}<br />${crop.name}<br>
                 <span class="crop-cost">${crop.cost} coins</span>
                 ${crop.rarity ? `<span class="crop-rarity">${crop.rarity}</span>` : ''}


### PR DESCRIPTION
## Summary
- show reward coins when hovering crop buttons

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686810359b948331be25c6deea24e534