### PR TITLE
Fix timed shop items

### DIFF
--- a/saveLoad.js
+++ b/saveLoad.js
@@ -42,6 +42,7 @@ function saveGameState() {
       crops: gameState.crops.map(c => ({ ...c, timerId: null, pestTimerId: null })),
       activeEffects: gameState.activeEffects.map(e => ({
         id: e.id,
+        itemId: e.itemId,
         itemName: e.itemName,
         effectType: e.effectType,
         value: e.value,

--- a/scripts.js
+++ b/scripts.js
@@ -1840,13 +1840,17 @@ function showToast(text, type) {
 }
 
 function startTimedEffect(item, effectType, value, duration) {
+    const maxDuration = 30 * 60 * 1000; // 30 minutes cap
+    const finalDuration = Math.min(duration, maxDuration);
+
     const effectId = `${item.id}_${effectType}`;
-    const expiresAt = Date.now() + duration;
+    const expiresAt = Date.now() + finalDuration;
     const timerId = setTimeout(() => {
         removeTimedEffect(effectId);
-    }, duration);
+    }, finalDuration);
     gameState.activeEffects.push({
         id: effectId,
+        itemId: item.id,
         itemName: item.name,
         icon: item.icon,
         effectType,
@@ -1886,6 +1890,13 @@ function removeTimedEffect(effectId) {
     }
     clearTimeout(effect.timerId);
     gameState.activeEffects.splice(index, 1);
+
+    if (effect.itemId && gameState.upgrades[effect.itemId] > 0) {
+        gameState.upgrades[effect.itemId]--;
+        if (gameState.upgrades[effect.itemId] < 0) gameState.upgrades[effect.itemId] = 0;
+        renderShop();
+    }
+
     showToast(`${effect.itemName} effect has worn off!`, 'info');
     renderEffectTimers();
 }

--- a/shop.json
+++ b/shop.json
@@ -448,7 +448,7 @@
     {
       "id": "honey_potion",
       "name": "Honey Potion",
-      "description": "Crop yield +25% for 1 hour!",
+      "description": "Crop yield +25% for 30 minutes!",
       "icon": "🍯",
       "category": "consumables",
       "cost": 500,
@@ -456,7 +456,7 @@
       "maxLevel": 99,
       "effects": {
         "crop_yield_bonus": 25,
-        "duration_minutes": 60
+        "duration_minutes": 30
       },
       "unlockCondition": {
         "type": "day",


### PR DESCRIPTION
## Summary
- limit consumable durations to 30 minutes
- make timed upgrades decrement their owned count when finished
- persist item id for active effects

## Testing
- `node -e "const fs=require('fs');JSON.parse(fs.readFileSync('shop.json'));console.log('shop.json ok');"`

------
https://chatgpt.com/codex/tasks/task_e_6868112f20c0833183e638ebde69aaee