### PR TITLE
Fix minigame timer overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,8 +148,10 @@
 <div class="minigame-overlay" id="minigameOverlay">
   <div class="minigame-container">
     <div class="minigame-header">
-      <h2 class="minigame-title" id="minigameTitle">Cow Challenge</h2>
-      <p class="minigame-instructions" id="minigameInstructions">Get ready to play!</p>
+      <div class="header-text">
+        <h2 class="minigame-title" id="minigameTitle">Cow Challenge</h2>
+        <p class="minigame-instructions" id="minigameInstructions">Get ready to play!</p>
+      </div>
       <div class="countdown-wrapper">
         <svg class="countdown-ring" width="70" height="70">
           <circle class="ring-bg" cx="35" cy="35" r="32"></circle>

--- a/styles.css
+++ b/styles.css
@@ -829,7 +829,7 @@ body {
 
 .minigame-container {
     height: 100%;
-    /* display: flex; */
+    display: flex;
     flex-direction: column;
     background: linear-gradient(145deg, #FFF8DC, #F5DEB3);
     padding: 20px 15px;
@@ -840,8 +840,10 @@ body {
 }
 
 .minigame-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     position: relative;
-    text-align: center;
     margin-bottom: 20px;
 }
 
@@ -860,6 +862,11 @@ body {
     margin-bottom: 10px;
 }
 
+.header-text {
+    flex: 1;
+    text-align: center;
+}
+
 .countdown-clock {
     position: absolute;
     top: 50%;
@@ -875,11 +882,10 @@ body {
 }
 
 .countdown-wrapper {
-    position: absolute;
-    top: 10px;
-    right: 10px;
+    position: relative;
     width: 70px;
     height: 70px;
+    margin-left: auto;
 }
 
 .countdown-ring {


### PR DESCRIPTION
## Summary
- restructure minigame header markup
- use flexbox layout for header to separate timer from title
- tweak minigame header styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686812ee0c6c8331afeaedf0a4de2e7d