### PR TITLE
UI cleanup and minigame tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,3 @@ Certain shop upgrades provide automation:
 
 The game automatically saves progress and works in modern browsers with JavaScript enabled.
 
-## Mood Ranking
-Use the **Sort by Mood** button on the Cows tab to display cows from saddest to happiest.
-You can also call `getCowMoodRanking()` in the browser console to retrieve the current order programmatically.

--- a/index.html
+++ b/index.html
@@ -73,7 +73,6 @@
     <div class="tab-content-wrapper"> 
       <!-- Cows Tab -->
       <div id="cowsTab" class="tab-content active">
-        <button class="sort-btn" onclick="showCowMoodRanking()">Sort by Mood</button>
         <div class="cows-grid grid-container" id="cowsGrid">
           <!-- Cows will be generated here -->
         </div>
@@ -170,12 +169,10 @@
         <div class="rhythm-bar" id="rhythmBar">
           <div class="rhythm-marker"></div>
         </div>
-      </div>
-    <div class="minigame-footer">
       <div class="mobile-controls">
         <button class="control-btn" id="tapBtn">&#x1F446;<br>TAP</button>
       </div>
-    </div>
+      </div>
   </div>
 </div>
 

--- a/scripts.js
+++ b/scripts.js
@@ -960,17 +960,6 @@ function updateAllCowHappiness() {
     renderCows();
 }
 
-// Return cows sorted from saddest to happiest
-function getCowMoodRanking() {
-    return [...gameState.cows].sort((a, b) => a.moodValue - b.moodValue);
-}
-
-// Display the current cow mood order in a toast message
-function showCowMoodRanking() {
-    const ranking = getCowMoodRanking();
-    const names = ranking.map(c => c.name).join(' -> ');
-    showToast(`Mood order: ${names}`, 'info');
-}
 
 function applyCowbellThreshold() {
     if (!gameState.upgrades || !gameState.upgrades.cowbell) return;

--- a/styles.css
+++ b/styles.css
@@ -400,30 +400,6 @@ body {
     box-shadow: none;
 }
 
-.sort-btn {
-    background: linear-gradient(145deg, #6A5ACD, #836FFF);
-    color: white;
-    border: none;
-    padding: 8px 12px;
-    border-radius: 15px;
-    font-family: 'Montserrat', sans-serif;
-    font-weight: bold;
-    font-size: 0.8em;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    box-shadow: 0 3px 10px rgba(106,90,205,0.3);
-    margin-bottom: 10px;
-}
-
-.sort-btn:hover {
-    background: linear-gradient(145deg, #483D8B, #6A5ACD);
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(106,90,205,0.4);
-}
-
-.sort-btn:active {
-    transform: scale(0.95);
-}
 
 .crops-section {
     background: rgba(255,255,255,0.9);
@@ -964,16 +940,17 @@ body {
 }
 
 .score-area {
-    background: linear-gradient(145deg, #FFF8DC, #F5DEB3);
-    border: 2px solid #DEB887;
-    border-radius: 12px;
-    padding: 10px;
-    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+    background: linear-gradient(145deg, #FFF1C1, #F5C58C);
+    border: 2px solid #D4A373;
+    border-radius: 15px;
+    padding: 15px;
+    box-shadow: 0 6px 15px rgba(0,0,0,0.15);
     margin-bottom: 15px;
     display: flex;
-    justify-content: space-around;
+    justify-content: center;
     align-items: center;
     text-align: center;
+    font-weight: 800;
 }
 
 .score-display {
@@ -1072,14 +1049,6 @@ body {
     transform: scale(0.95);
 }
 
-.minigame-footer {
-    margin-top: auto;
-    /* display: flex; */
-    flex-direction: column;
-    align-items: center;
-    gap: 15px;
-}
-
 
 /* Mobile Toast Messages */
 .toast-message {
@@ -1137,6 +1106,9 @@ body {
     border: 3px solid #8B4513;
 }
 
+.result-text {
+    margin-bottom: 15px;
+}
 
 .close-achievement {
     position: absolute;


### PR DESCRIPTION
## Summary
- remove mood ranking button and related JS
- reposition the minigame tap button under the rhythm bar
- restyle the score area
- add spacing to result text
- clean up README reference to mood sorting

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68681f19badc833184a22c4f887ada77