### PR TITLE
Fix overlapping minigame timers

### DIFF
--- a/minigame.js
+++ b/minigame.js
@@ -6,6 +6,7 @@ let currentMinigame = {
     target: 100,
     noteInterval: null,
     countdownInterval: null,
+    gameTimeout: null,
     timeLeft: COUNTDOWN_TOTAL,
     gameActive: false,
     combo: 0,
@@ -82,7 +83,9 @@ function startRhythmGame(cowIndex) {
 
     clearNotes();
 
+    clearInterval(currentMinigame.noteInterval);
     clearInterval(currentMinigame.countdownInterval);
+    clearTimeout(currentMinigame.gameTimeout);
     currentMinigame.countdownInterval = setInterval(() => {
         currentMinigame.timeLeft--;
         if (countdownEl) countdownEl.textContent = formatTime(Math.max(0, currentMinigame.timeLeft));
@@ -101,7 +104,7 @@ function startRhythmGame(cowIndex) {
         }
     }, speed);
     
-    setTimeout(() => {
+    currentMinigame.gameTimeout = setTimeout(() => {
         if (currentMinigame.gameActive) {
             endMinigame();
         }
@@ -326,6 +329,7 @@ function endMinigame() {
     currentMinigame.gameActive = false;
     clearInterval(currentMinigame.noteInterval);
     clearInterval(currentMinigame.countdownInterval);
+    clearTimeout(currentMinigame.gameTimeout);
     clearNotes();
 
     // Reveal the close button now that the game has ended


### PR DESCRIPTION
## Summary
- add `gameTimeout` to track end-of-game timer
- clear all timers when starting or ending the rhythm minigame

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68685058f6b083319e84e5d1e8d6173b