### PR TITLE
Add slide-out menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 <div class="mobile-container"> 
   <!-- Game Header -->
   <div class="game-header">
+    <button id="menuButton" class="menu-button">&#9776;</button>
     <div class="header-content">
       <h1 class="game-title">&#x1F404; MOO-D SWINGS &#x1F404;</h1>
 
@@ -116,30 +117,50 @@
             <!-- Achievements will be displayed here --> 
           </div>
         </div>
-        <div class="save-system-container">
-          <h3 class="section-title section-title-green">&#x1F4BE; SAVE SYSTEM &#x1F4BE;</h3>
-          <div class="save-info-text">
-            Player ID: <span id="playerID" class="save-info-label"></span><br>
-            Last Saved: <span id="lastSaved" class="save-info-label">Never</span>
-          </div>
-          <div class="save-button-grid">
-            <button onclick="saveGameState(); showToast('Game saved!', 'success'); updateSaveInfo();" class="save-button save-button-save">&#x1F4BE; Save</button>
-            <button onclick="resetGameData()" class="save-button save-button-reset">&#x1F5D1;&#xFE0F; Reset</button>
-          </div>
-          <div class="save-help-text">
-            Auto-saves every 2 minutes and when you leave.
-          </div>
-        </div>
-        <div class="debug-container">
-          <h3 class="section-title section-title-purple">&#x1F527; DEBUG TOOLS &#x1F527;</h3>
-          <button onclick="debugUnlockSystem()" class="debug-button debug-button-pink">&#x1F50D; Check Unlock Status</button>
-          <button onclick="forceUnlockCheck()" class="debug-button debug-button-green">&#x1F513; Force Unlock Check</button>
-        </div>
       </div>
     </div>
     <div class="next-day-bar">
       <button class="action-btn" onclick="nextDay()"><i class="fa-solid fa-sun btn-icon"></i>Next Day</button>
     </div>
+  </div>
+</div>
+
+<!-- Slide-out Menu -->
+<div id="sideMenu" class="side-menu">
+  <button id="closeMenu" class="close-menu">&times;</button>
+
+  <div class="menu-section save-system-container">
+    <h3 class="section-title section-title-green">&#x1F4BE; SAVE SYSTEM &#x1F4BE;</h3>
+    <div class="save-info-text">
+      Player ID: <span id="playerID" class="save-info-label"></span><br>
+      Last Saved: <span id="lastSaved" class="save-info-label">Never</span>
+    </div>
+    <div class="save-button-grid">
+      <button onclick="saveGameState(); showToast('Game saved!', 'success'); updateSaveInfo();" class="save-button save-button-save">&#x1F4BE; Save</button>
+      <button onclick="resetGameData()" class="save-button save-button-reset">&#x1F5D1;&#xFE0F; Reset</button>
+    </div>
+    <div class="save-help-text">Auto-saves every 2 minutes and when you leave.</div>
+  </div>
+
+  <div class="menu-section debug-container">
+    <h3 class="section-title section-title-purple">&#x1F527; DEBUG TOOLS &#x1F527;</h3>
+    <button onclick="debugUnlockSystem()" class="debug-button debug-button-pink">&#x1F50D; Check Unlock Status</button>
+    <button onclick="forceUnlockCheck()" class="debug-button debug-button-green">&#x1F513; Force Unlock Check</button>
+  </div>
+
+  <div class="menu-section about-container">
+    <h3 class="section-title section-title-yellow">&#x2139;&#xFE0F; ABOUT</h3>
+    <p>Moo-d Swings is a light rhythm farming game built for fun!</p>
+  </div>
+
+  <div class="menu-section help-container">
+    <h3 class="section-title section-title-blue">&#x2753; HELP</h3>
+    <p>Tap cows for rhythm challenges and plant crops to earn coins.</p>
+  </div>
+
+  <div class="menu-section settings-container">
+    <h3 class="section-title section-title-brown">&#9881;&#xFE0F; SETTINGS</h3>
+    <label class="toggle-sound"><input type="checkbox" id="soundToggle" checked> Sound</label>
   </div>
 </div>
 

--- a/scripts.js
+++ b/scripts.js
@@ -2529,3 +2529,19 @@ if (scrollTopBtn) {
         window.scrollTo({ top: 0, behavior: 'smooth' });
     });
 }
+
+// Slide-out menu functionality
+const menuButton = document.getElementById('menuButton');
+const sideMenu = document.getElementById('sideMenu');
+const closeMenu = document.getElementById('closeMenu');
+if (menuButton && sideMenu && closeMenu) {
+    menuButton.addEventListener('click', () => sideMenu.classList.add('open'));
+    closeMenu.addEventListener('click', () => sideMenu.classList.remove('open'));
+}
+
+const soundToggle = document.getElementById('soundToggle');
+if (soundToggle) {
+    soundToggle.addEventListener('change', (e) => {
+        gameState.soundOn = e.target.checked;
+    });
+}

--- a/styles.css
+++ b/styles.css
@@ -345,6 +345,58 @@ body {
     grid-template-columns: repeat(2, 1fr);
 }
 
+/* Slide-out menu */
+.menu-button {
+    position: absolute;
+    left: 10px;
+    top: 10px;
+    background: var(--barn-red);
+    color: white;
+    border: none;
+    font-size: 1.5em;
+    padding: 5px 10px;
+    border-radius: 5px;
+    z-index: 1002;
+}
+
+.side-menu {
+    position: fixed;
+    top: 0;
+    left: -260px;
+    width: 250px;
+    height: 100%;
+    background: var(--dark-teal);
+    color: white;
+    overflow-y: auto;
+    transition: left 0.3s ease;
+    z-index: 1001;
+    padding: 20px;
+}
+.side-menu.open {
+    left: 0;
+}
+.close-menu {
+    background: none;
+    border: none;
+    color: white;
+    font-size: 1.5em;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    cursor: pointer;
+}
+.side-menu .menu-section {
+    margin-bottom: 20px;
+}
+.side-menu .menu-section h3 {
+    margin-bottom: 10px;
+}
+.toggle-sound {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
 
 .cow-card {
     background: #FFF8DC;
@@ -2000,6 +2052,7 @@ body {
 .section-title-blue { color: #4169E1; }
 .section-title-green { color: #228B22; }
 .section-title-purple { color: #8B008B; }
+.section-title-yellow { color: var(--sunflower-yellow); }
 
 /* Stats Tab Containers */
 .bulletin-board {


### PR DESCRIPTION
## Summary
- add menu button in header
- move save system and debug tools to new slide-out menu
- add About, Help, and Settings sections
- style and script slide-out menu functionality

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68685b1a5e588331b7fac318f34ed933