### PR TITLE
Add five new crops

### DIFF
--- a/crops.json
+++ b/crops.json
@@ -212,6 +212,76 @@
         "target": 20
       },
       "description": "Legendary orchard treasure!"
+    },
+    {
+      "id": "peach",
+      "name": "Peach",
+      "emoji": "🍑",
+      "cost": 90,
+      "value": 117,
+      "growTime": 95000,
+      "rarity": "uncommon",
+      "unlockCondition": {
+        "type": "day",
+        "target": 6
+      },
+      "description": "Sweet and fuzzy!"
+    },
+    {
+      "id": "grape",
+      "name": "Grape",
+      "emoji": "🍇",
+      "cost": 95,
+      "value": 124,
+      "growTime": 100000,
+      "rarity": "uncommon",
+      "unlockCondition": {
+        "type": "day",
+        "target": 7
+      },
+      "description": "Tiny bunch, big returns!"
+    },
+    {
+      "id": "banana",
+      "name": "Banana",
+      "emoji": "🍌",
+      "cost": 180,
+      "value": 234,
+      "growTime": 360000,
+      "rarity": "rare",
+      "unlockCondition": {
+        "type": "totalCoins",
+        "target": 1200
+      },
+      "description": "A-peeling profits!"
+    },
+    {
+      "id": "coconut",
+      "name": "Coconut",
+      "emoji": "🥥",
+      "cost": 250,
+      "value": 325,
+      "growTime": 450000,
+      "rarity": "rare",
+      "unlockCondition": {
+        "type": "day",
+        "target": 12
+      },
+      "description": "Tropical treat with tough shell!"
+    },
+    {
+      "id": "coffee_bean",
+      "name": "Coffee Bean",
+      "emoji": "☕",
+      "cost": 500,
+      "value": 650,
+      "growTime": 650000,
+      "rarity": "epic",
+      "unlockCondition": {
+        "type": "totalCoins",
+        "target": 2500
+      },
+      "description": "Perk up your income!"
     }
   ],
   "cropCategories": {


### PR DESCRIPTION
## Summary
- expand farming options with peach, grape, banana, coconut and coffee bean crops

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68688cd762708331889687823413bcce