### PR TITLE
Reduce cow happiness decay

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Modify the JSON files to add new cows, crops, shop items or rhythm patterns. You
 - Plant and harvest crops for additional income.
 - Spend coins or milk on upgrades in the shop.
 - Unlock more content as you progress through the days.
+ - Keeping cows at full happiness for a while will level them up.
  - Seasons follow the real-world date, changing crop growth speed and cow mood.
  - Weather shifts throughout the day and displays the current temperature.
 - The header displays the current local time so you know what part of the day the farm is themed for.

--- a/config.js
+++ b/config.js
@@ -118,7 +118,11 @@ const GAME_CONFIG = {
         success_bonus: 20,
         failure_penalty: 10,
         // Mood decreases by about 3% of the current value every hour
-        decay_rate_percent: 0.03
+        decay_rate_percent: 0.03,
+        // When a cow is at max happiness, pause decay for this many minutes
+        full_happy_grace_minutes: 10,
+        // How many hours of full happiness are required to level up a cow
+        level_up_hours: 2
     },
 
     HAPPINESS_UPDATE_INTERVAL: 3600000, // 1 hour

--- a/scripts.js
+++ b/scripts.js
@@ -1029,6 +1029,12 @@ function updateCowHappiness(cow) {
     const now = Date.now();
     const hours = (now - (cow.lastHappinessUpdate || now)) / 3600000;
     if (hours <= 0) return;
+    const graceMs = (GAME_CONFIG.HAPPINESS.full_happy_grace_minutes || 0) * 60000;
+    if (cow.fullHappySince && (now - cow.fullHappySince) < graceMs) {
+        cow.lastHappinessUpdate = now;
+        return;
+    }
+
     const rate = GAME_CONFIG.HAPPINESS.decay_rate_percent;
     const decayAmount = cow.happinessLevel * rate * hours;
     cow.happinessLevel = Math.max(
@@ -1047,7 +1053,7 @@ function checkCowLevelUp(cow) {
     if (!cow.fullHappySince) return;
 
     const elapsed = Date.now() - cow.fullHappySince;
-    const hoursRequired = 12 * 3600000;
+    const hoursRequired = (GAME_CONFIG.HAPPINESS.level_up_hours || 12) * 3600000;
     if (elapsed < hoursRequired) return;
 
     const type = cow.currentGameType || cow.gameType;


### PR DESCRIPTION
## Summary
- allow some grace time when cows reach max happiness so decay won't immediately reset the level timer
- make the level-up requirement configurable and shorter by default
- mention cow leveling in README

## Testing
- `node --check scripts.js`
- `node --check config.js`

------
https://chatgpt.com/codex/tasks/task_e_68688d7b6e088331aa8e1f42f7ca187c