### PR TITLE
Fix night theme text visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2200,6 +2200,13 @@ body.night {
     background: var(--dark-teal);
 }
 
+/* Ensure header text remains visible on dark background */
+.game-header.night .stat-icon,
+.game-header.night .stat-value,
+.game-header.night .stat-label {
+    color: var(--cow-white);
+}
+
 /* Season theme backgrounds */
 body.season-spring {
     background: var(--grass-green);


### PR DESCRIPTION
## Summary
- ensure game header text stays white during night theme

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686895b9b58c8331bbf26c1eb2ee3895