### PR TITLE
Single-use consumables

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,11 @@ Certain shop upgrades provide automation:
 - **Milk Processor** converts all stored milk into coins at the start of each day using its conversion rate.
 
 - **Pest Control** keeps pests away from your fields. The basic version lasts five minutes and
-  upgraded ones extend the duration up to thirty minutes. Each use consumes one item and you can
-  stockpile up to 100.
+  upgraded ones extend the duration up to thirty minutes. Each use consumes one item.
 
 ### Consumables
-Single-use boosts like Energy Drinks or Super Fertilizer can be bought in bulk. You decide when to
-activate them and improved versions offer stronger or longer effects.
+Single-use boosts like Energy Drinks or Super Fertilizer can only be purchased one at a time.
+Activate them when needed, and improved versions offer stronger or longer effects.
 
 The game automatically saves progress and works in modern browsers with JavaScript enabled.
 

--- a/shop.json
+++ b/shop.json
@@ -344,7 +344,7 @@
       "category": "consumables",
       "cost": 50,
       "currency": "coins",
-      "maxLevel": 99,
+      "maxLevel": 1,
       "effects": {
         "action_speed_boost": 20,
         "duration_minutes": 15
@@ -362,7 +362,7 @@
       "category": "consumables",
       "cost": 60,
       "currency": "coins",
-      "maxLevel": 99,
+      "maxLevel": 1,
       "effects": {
         "happiness_boost_percent": 5,
         "duration_minutes": 15
@@ -380,7 +380,7 @@
       "category": "consumables",
       "cost": 80,
       "currency": "coins",
-      "maxLevel": 99,
+      "maxLevel": 1,
       "effects": {
         "extra_milk_per_click": 1,
         "duration_minutes": 15
@@ -398,7 +398,7 @@
       "category": "consumables",
       "cost": 90,
       "currency": "coins",
-      "maxLevel": 20,
+      "maxLevel": 1,
       "effects": {
         "pest_protection": true,
         "duration_minutes": 5
@@ -416,7 +416,7 @@
       "category": "consumables",
       "cost": 180,
       "currency": "coins",
-      "maxLevel": 20,
+      "maxLevel": 1,
       "effects": {
         "pest_protection": true,
         "duration_minutes": 10
@@ -434,7 +434,7 @@
       "category": "consumables",
       "cost": 270,
       "currency": "coins",
-      "maxLevel": 20,
+      "maxLevel": 1,
       "effects": {
         "pest_protection": true,
         "duration_minutes": 15
@@ -452,7 +452,7 @@
       "category": "consumables",
       "cost": 360,
       "currency": "coins",
-      "maxLevel": 20,
+      "maxLevel": 1,
       "effects": {
         "pest_protection": true,
         "duration_minutes": 20
@@ -470,7 +470,7 @@
       "category": "consumables",
       "cost": 450,
       "currency": "coins",
-      "maxLevel": 20,
+      "maxLevel": 1,
       "effects": {
         "pest_protection": true,
         "duration_minutes": 25
@@ -488,7 +488,7 @@
       "category": "consumables",
       "cost": 540,
       "currency": "coins",
-      "maxLevel": 20,
+      "maxLevel": 1,
       "effects": {
         "pest_protection": true,
         "duration_minutes": 30
@@ -506,7 +506,7 @@
       "category": "consumables",
       "cost": 100,
       "currency": "coins",
-      "maxLevel": 99,
+      "maxLevel": 1,
       "effects": {
         "crop_growth_speed": 50,
         "duration_minutes": 15
@@ -524,7 +524,7 @@
       "category": "consumables",
       "cost": 100,
       "currency": "coins",
-      "maxLevel": 99,
+      "maxLevel": 1,
       "effects": {
         "coin_bonus_percent": 5,
         "duration_minutes": 30
@@ -542,7 +542,7 @@
       "category": "consumables",
       "cost": 120,
       "currency": "coins",
-      "maxLevel": 99,
+      "maxLevel": 1,
       "effects": {
         "coin_bonus_percent": 10,
         "duration_minutes": 30
@@ -560,7 +560,7 @@
       "category": "consumables",
       "cost": 500,
       "currency": "coins",
-      "maxLevel": 99,
+      "maxLevel": 1,
       "effects": {
         "crop_yield_bonus": 25,
         "duration_minutes": 30


### PR DESCRIPTION
## Summary
- prevent stacking of consumables by capping `maxLevel` at 1
- adjust shop description in README

## Testing
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('shop.json')); console.log('OK');"`

------
https://chatgpt.com/codex/tasks/task_e_686897e89fe88331bd20495dcfe3d45a