### PR TITLE
Add About page with FAQs

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About - Moo-d Swings</title>
+  <link rel="stylesheet" href="styles.css?v=moo3.5">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+</head>
+<body>
+  <div class="mobile-container">
+    <header class="page-header">
+      <span class="logo">&#x1F404; MOO-D SWINGS</span>
+      <div class="header-buttons">
+        <a href="index.html" class="about-link">Back</a>
+      </div>
+    </header>
+    <main class="about-main">
+      <h1>About</h1>
+      <p>Moo-d Swings is a light rhythm farming game built for fun!</p>
+      <section id="faqSection">
+        <h2>Frequently Asked Questions</h2>
+        <div id="faqList"></div>
+      </section>
+    </main>
+  </div>
+  <script src="about.js?v=1.0"></script>
+</body>
+</html>

--- a/about.js
+++ b/about.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const res = await fetch('faqs.json');
+    const data = await res.json();
+    const container = document.getElementById('faqList');
+    data.faqs.forEach(faq => {
+      const item = document.createElement('div');
+      item.className = 'faq-item';
+      item.innerHTML = `<h3>${faq.question}</h3><p>${faq.answer}</p>`;
+      container.appendChild(item);
+    });
+  } catch (err) {
+    console.error('Failed to load FAQs', err);
+  }
+});

--- a/faqs.json
+++ b/faqs.json
@@ -1,0 +1,16 @@
+{
+  "faqs": [
+    {
+      "question": "How do I start playing?",
+      "answer": "Tap on a cow to begin a rhythm challenge and earn coins." 
+    },
+    {
+      "question": "What do coins do?",
+      "answer": "Coins let you purchase crops and upgrades from the shop." 
+    },
+    {
+      "question": "How can I save my progress?",
+      "answer": "Use the save option in the menu; the game also auto-saves periodically." 
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -22,7 +22,10 @@
 <div class="mobile-container"> 
   <header class="page-header">
     <span class="logo">&#x1F404; MOO-D SWINGS</span>
-    <button id="menuButton" class="menu-button">&#9776;</button>
+    <div class="header-buttons">
+      <a href="about.html" class="about-link">About</a>
+      <button id="menuButton" class="menu-button">&#9776;</button>
+    </div>
   </header>
   <!-- Game Header -->
   <div class="game-header">

--- a/styles.css
+++ b/styles.css
@@ -357,6 +357,15 @@ body {
     grid-template-columns: repeat(2, 1fr);
 }
 
+/* About/FAQ page */
+.faq-item {
+    margin-bottom: 15px;
+}
+
+.faq-item h3 {
+    margin-bottom: 5px;
+}
+
 /* Slide-out menu */
 .menu-button {
     background: var(--barn-red);
@@ -366,6 +375,21 @@ body {
     padding: 5px 10px;
     border-radius: 5px;
     z-index: 1002;
+}
+
+.header-buttons {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.about-link {
+    background: var(--barn-red);
+    color: white;
+    padding: 5px 10px;
+    font-size: 1em;
+    border-radius: 5px;
+    text-decoration: none;
 }
 
 .side-menu {


### PR DESCRIPTION
## Summary
- add About page and supporting script
- load FAQs from new `faqs.json`
- add navigation link to About in header
- style new navigation and FAQ section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68695316f08883319f484f46de7a00c4