### PR TITLE
Add leaderboard page

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,11 @@
     <h3 class="section-title section-title-yellow">&#x2139;&#xFE0F; ABOUT</h3>
     <p>Moo-d Swings is a light rhythm farming game built for fun!</p>
   </div>
+  <div class="menu-section leaderboard-container">
+    <h3 class="section-title section-title-green">&#x1F3C6; LEADERBOARD</h3>
+    <a href="leaderboard.html" class="about-link">View Leaderboard</a>
+  </div>
+
 
   <div class="menu-section help-container">
     <h3 class="section-title section-title-blue">&#x2753; HELP</h3>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Leaderboard - Moo-d Swings</title>
+  <link rel="stylesheet" href="styles.css?v=moo3.5">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+</head>
+<body>
+  <div class="mobile-container">
+    <header class="page-header">
+      <span class="logo">&#x1F404; MOO-D SWINGS</span>
+      <div class="header-buttons">
+        <a href="index.html" class="about-link">Back</a>
+      </div>
+    </header>
+    <main class="about-main">
+      <h1>Leaderboard</h1>
+      <table id="leaderboardTable" class="leaderboard-table">
+        <thead>
+          <tr><th>Player</th><th>XP</th><th>Farm Age (Days)</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </main>
+  </div>
+  <script src="leaderboard.js?v=1.0"></script>
+</body>
+</html>

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const res = await fetch('leaderboard.json');
+    const data = await res.json();
+    data.players.sort((a, b) => b.xp - a.xp);
+    const tbody = document.querySelector('#leaderboardTable tbody');
+    data.players.forEach(player => {
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${player.name}</td><td>${player.xp}</td><td>${player.days}</td>`;
+      tbody.appendChild(row);
+    });
+  } catch (err) {
+    console.error('Failed to load leaderboard', err);
+  }
+});

--- a/leaderboard.json
+++ b/leaderboard.json
@@ -1,0 +1,8 @@
+{
+  "players": [
+    { "name": "Farmer Joe", "xp": 1500, "days": 12 },
+    { "name": "Farmer Jane", "xp": 2100, "days": 15 },
+    { "name": "Cowboy Carl", "xp": 750, "days": 8 },
+    { "name": "Rancher Rick", "xp": 3200, "days": 22 }
+  ]
+}

--- a/styles.css
+++ b/styles.css
@@ -2341,3 +2341,20 @@ body.season-winter {
 .cows-grid {
     grid-template-columns: repeat(2, 1fr);
 }
+
+/* Leaderboard Styles */
+.leaderboard-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.leaderboard-table th,
+.leaderboard-table td {
+    border: 1px solid #ccc;
+    padding: 6px;
+    text-align: left;
+}
+.leaderboard-table th {
+    background: var(--pasture-green);
+    color: #fff;
+}
+


### PR DESCRIPTION
## Summary
- create `leaderboard.html` and JavaScript to load scores
- style leaderboard table
- store sample leaderboard data in `leaderboard.json`
- link leaderboard from the side menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686954124bc08331a80a8a0d55bd98e6