### PR TITLE
Add dynamic local leaderboard updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Activate them when needed, and improved versions offer stronger or longer effect
 
 The game automatically saves progress and works in modern browsers with JavaScript enabled.
 
+## Local Leaderboard
+Each save also updates a `leaderboardData` record in your browser's localStorage.
+Visit `leaderboard.html` to see the highest XP totals from saves on your device.
+
 ## Color Palette
 Below is the full palette used throughout the game. Each color has a specific purpose and mood to help keep the visuals cohesive.
 

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,9 +1,17 @@
 document.addEventListener('DOMContentLoaded', async () => {
   try {
-    const res = await fetch('leaderboard.json');
-    const data = await res.json();
+    let data;
+    const stored = localStorage.getItem('leaderboardData');
+    if (stored) {
+      data = JSON.parse(stored);
+    } else {
+      const res = await fetch('leaderboard.json');
+      data = await res.json();
+    }
+
     data.players.sort((a, b) => b.xp - a.xp);
     const tbody = document.querySelector('#leaderboardTable tbody');
+    tbody.innerHTML = '';
     data.players.forEach(player => {
       const row = document.createElement('tr');
       row.innerHTML = `<td>${player.name}</td><td>${player.xp}</td><td>${player.days}</td>`;

--- a/saveLoad.js
+++ b/saveLoad.js
@@ -52,6 +52,8 @@ function saveGameState() {
 
     localStorage.setItem(SAVE_KEY, JSON.stringify(saveData));
     console.log('Game saved to localStorage');
+    // Update local leaderboard with latest stats
+    updateLocalLeaderboard(saveData);
     updateSaveInfo();
     return saveData;
   } catch (err) {
@@ -213,6 +215,30 @@ function resetGameData() {
         // Restart the game
         initializeGame();
         showToast('Game reset! Starting fresh.', 'success');
+    }
+}
+
+// Update leaderboard stored in localStorage with latest save info
+function updateLocalLeaderboard(state) {
+    try {
+        const key = 'leaderboardData';
+        const raw = localStorage.getItem(key);
+        const data = raw ? JSON.parse(raw) : { players: [] };
+
+        const name = state.username || state.playerID;
+        let entry = data.players.find(p => p.id === state.playerID);
+        if (entry) {
+            entry.name = name;
+            entry.xp = state.xp;
+            entry.days = state.day;
+        } else {
+            data.players.push({ id: state.playerID, name, xp: state.xp, days: state.day });
+        }
+
+        data.players.sort((a, b) => b.xp - a.xp);
+        localStorage.setItem(key, JSON.stringify(data));
+    } catch (err) {
+        console.error('Error updating leaderboard', err);
     }
 }
 


### PR DESCRIPTION
## Summary
- update README with note about local leaderboard
- keep leaderboard data in `localStorage`
- save leaderboard data whenever a game saves

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6869571ce8d8833182a773ed38152a60