### PR TITLE
Fix cow level timer reset

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1103,6 +1103,9 @@ function checkCowLevelUp(cow) {
 
     cow.level = prevLevel + 1;
     cow.fullHappySince = null;
+    // Reset mood after leveling up so players must cheer the cow again
+    cow.happinessLevel = 25;
+    refreshCowMood(cow);
     showToast(`🐮 ${cow.name} reached Lv ${cow.level}!`, 'success');
 }
 


### PR DESCRIPTION
## Summary
- reset cow happiness to 25 once the level timer completes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68695a17c33883319543380367e51df8