### PR TITLE
Fix undefined harvest timestamps causing achievements error

### DIFF
--- a/saveLoad.js
+++ b/saveLoad.js
@@ -204,7 +204,8 @@ function resetGameData() {
                 currentPerfectStreak: 0,
                 upgradesPurchased: 0,
                 secretCowsUnlocked: 0,
-                playedAtMidnight: false
+                playedAtMidnight: false,
+                harvestTimestamps: []
             },
             perfectStreakRecord: 0,
             activeCropTimers: [],

--- a/scripts.js
+++ b/scripts.js
@@ -2444,8 +2444,13 @@ function migrateGameState() {
             currentPerfectStreak: 0,
             upgradesPurchased: 0,
             secretCowsUnlocked: 0,
-        playedAtMidnight: false
+            playedAtMidnight: false,
+            harvestTimestamps: []
     };
+    }
+    // Ensure new fields exist when migrating older saves
+    if (!gameState.stats.harvestTimestamps) {
+        gameState.stats.harvestTimestamps = [];
     }
 
     if (!gameState.dailyMilkTotals) {


### PR DESCRIPTION
## Summary
- ensure `harvestTimestamps` exists when migrating older saves
- include `harvestTimestamps` in the default stats when resetting the game

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68695bc996d88331b38af25cebdcd68e