### PR TITLE
Add username prompt and cleanup settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,10 +184,6 @@
 
   <div class="menu-section settings-container">
     <h3 class="section-title section-title-brown">&#9881;&#xFE0F; SETTINGS</h3>
-    <div class="username-setting">
-      <input id="usernameInput" type="text" placeholder="Your name">
-      <button class="save-button save-button-save" onclick="updateUsername()">Set Name</button>
-    </div>
   </div>
 </div>
 

--- a/saveLoad.js
+++ b/saveLoad.js
@@ -160,7 +160,21 @@ function importGameData() {
 
 function resetGameData() {
     if (confirm('Are you sure you want to reset all game data? This cannot be undone!')) {
+        const oldId = gameState.playerID;
         clearAllCropTimers();
+
+        // Remove player entry from leaderboard
+        try {
+            const key = 'leaderboardData';
+            const raw = localStorage.getItem(key);
+            if (raw) {
+                const data = JSON.parse(raw);
+                data.players = data.players.filter(p => p.id !== oldId);
+                localStorage.setItem(key, JSON.stringify(data));
+            }
+        } catch (err) {
+            console.error('Error removing from leaderboard', err);
+        }
 
         // Remove any saved data so a fresh game starts on reload
         localStorage.removeItem(SAVE_KEY);
@@ -213,7 +227,7 @@ function resetGameData() {
             currentSeasonIndex: 0,
             currentWeatherIndex: 0,
             username: '',
-            playerID: generateDeviceID(),
+            playerID: '',
             lastSaved: null,
             gameVersion: "2.1"
         });

--- a/scripts.js
+++ b/scripts.js
@@ -917,9 +917,26 @@ function updateUsername() {
     if (!input) return;
     const name = input.value.trim();
     gameState.username = name;
+    gameState.playerID = name;
     saveGameState();
     updateSaveInfo();
     showToast('Username updated!', 'success');
+}
+
+function promptForUsername() {
+    let name = '';
+    while (!name) {
+        name = prompt('Enter your name (letters and numbers only):', '') || '';
+        name = name.trim();
+        if (name && !/^[A-Za-z0-9]+$/.test(name)) {
+            alert('Name must contain only letters and numbers.');
+            name = '';
+        }
+    }
+    gameState.username = name;
+    gameState.playerID = name;
+    saveGameState();
+    updateSaveInfo();
 }
 
 
@@ -2533,14 +2550,19 @@ function initializeGame() {
     // Try to load saved game first
     const loadedSave = loadGameState();
     migrateGameState();
-    
+
     if (!loadedSave) {
-        // New game - initialize everything
+        // New game - ask for username and initialize everything
+        promptForUsername();
         generateCows();
         initializeCrops();
         updateSeason();
         updateWeather(true);
     } else {
+        // Loaded game - ask for username if missing and reinitialize display elements
+        if (!gameState.username || !gameState.playerID) {
+            promptForUsername();
+        }
         // Loaded game - reinitialize display elements
         generateCows(); // This will use existing cow data
         renderCrops(); // This will use existing crop data

--- a/styles.css
+++ b/styles.css
@@ -2136,24 +2136,6 @@ body {
     line-height: 1.2;
 }
 
-.username-setting {
-    display: flex;
-    gap: 6px;
-    margin-top: 10px;
-}
-
-.username-setting input {
-    flex: 1;
-    padding: 6px;
-    border-radius: 6px;
-    border: 1px solid #ccc;
-    font-family: 'Montserrat', sans-serif;
-    font-size: 0.8em;
-}
-
-.username-setting button {
-    flex-shrink: 0;
-}
 
 .claim-reward-btn {
     margin-top: 4px;


### PR DESCRIPTION
## Summary
- ask for a username when starting a new game
- keep username as the player ID
- remove rename option from the menu
- strip username styles
- clear leaderboard entry when resetting the game

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68695de6806c8331a052367e02b4e4a4