### PR TITLE
Switch reset confirm to custom modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,18 @@
   </div>
 </div>
 
+<!-- Reset Confirmation Overlay -->
+<div class="reset-overlay" id="resetOverlay">
+  <div class="reset-container">
+    <h2 class="reset-title">Reset Game?</h2>
+    <p class="reset-text">All progress will be lost.</p>
+    <div class="reset-buttons">
+      <button class="reset-confirm" onclick="confirmResetGameData()">Reset</button>
+      <button class="reset-cancel" onclick="hideResetOverlay()">Cancel</button>
+    </div>
+  </div>
+</div>
+
 <!-- Mobile Toast Messages -->
 <div class="toast-message" id="toastMessage"></div>
 <div class="achievement-popup" id="achievementPopup"></div>

--- a/saveLoad.js
+++ b/saveLoad.js
@@ -159,9 +159,27 @@ function importGameData() {
 }
 
 function resetGameData() {
-    if (confirm('Are you sure you want to reset all game data? This cannot be undone!')) {
-        const oldId = gameState.playerID;
-        clearAllCropTimers();
+    const overlay = document.getElementById('resetOverlay');
+    if (overlay) {
+        overlay.style.display = 'flex';
+    } else if (confirm('Are you sure you want to reset all game data? This cannot be undone!')) {
+        performResetGameData();
+    }
+}
+
+function hideResetOverlay() {
+    const overlay = document.getElementById('resetOverlay');
+    if (overlay) overlay.style.display = 'none';
+}
+
+function confirmResetGameData() {
+    hideResetOverlay();
+    performResetGameData();
+}
+
+function performResetGameData() {
+    const oldId = gameState.playerID;
+    clearAllCropTimers();
 
         // Remove player entry from leaderboard
         try {

--- a/styles.css
+++ b/styles.css
@@ -928,6 +928,73 @@ body {
     transform: scale(0.98);
 }
 
+/* Reset Confirmation Overlay */
+.reset-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    touch-action: manipulation;
+    font-family: 'Montserrat', sans-serif;
+}
+
+.reset-container {
+    background: #FFF8DC;
+    border: 4px solid var(--earth-brown);
+    border-radius: 20px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+    margin: 40px 15px;
+    padding: 20px 15px;
+    color: var(--earth-brown);
+    text-align: center;
+}
+
+.reset-title {
+    font-size: 1.2em;
+    font-weight: 700;
+    margin-bottom: 10px;
+}
+
+.reset-text {
+    margin-bottom: 15px;
+}
+
+.reset-buttons {
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+}
+
+.reset-confirm,
+.reset-cancel {
+    padding: 10px 20px;
+    border: none;
+    border-radius: 10px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.reset-confirm {
+    background: var(--accent-pink);
+    color: white;
+}
+
+.reset-cancel {
+    background: var(--pastel-mint);
+    color: white;
+}
+
+.reset-confirm:active,
+.reset-cancel:active {
+    transform: scale(0.98);
+}
+
 /* Meteor shower overlay */
 .meteor-overlay {
     position: fixed;


### PR DESCRIPTION
## Summary
- add a reset confirmation modal in HTML/CSS
- replace `confirm()` in `resetGameData` with the new modal

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686963f781ac8331a954aabbcc5fb9db