### PR TITLE
Reorder side menu sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,6 +146,15 @@
 <div id="sideMenu" class="side-menu">
   <button id="closeMenu" class="close-menu">&times;</button>
 
+  <div class="menu-section leaderboard-container">
+    <h3 class="section-title section-title-green">&#x1F3C6; LEADERBOARD</h3>
+    <a href="leaderboard.html" class="about-link">View Leaderboard</a>
+  </div>
+  <div class="menu-section about-container">
+    <h3 class="section-title section-title-yellow">&#x2139;&#xFE0F; ABOUT</h3>
+    <p>Moo-d Swings is a light rhythm farming game built for fun!</p>
+    <a href="about.html" class="about-link">About &amp; FAQ</a>
+  </div>
   <div class="menu-section save-system-container">
     <h3 class="section-title section-title-green">&#x1F4BE; SAVE SYSTEM &#x1F4BE;</h3>
     <div class="save-info-text">
@@ -164,16 +173,6 @@
     <h3 class="section-title section-title-purple">&#x1F527; DEBUG TOOLS &#x1F527;</h3>
     <button onclick="debugUnlockSystem()" class="debug-button debug-button-pink">&#x1F50D; Check Unlock Status</button>
     <button onclick="forceUnlockCheck()" class="debug-button debug-button-green">&#x1F513; Force Unlock Check</button>
-  </div>
-
-  <div class="menu-section about-container">
-    <h3 class="section-title section-title-yellow">&#x2139;&#xFE0F; ABOUT</h3>
-    <p>Moo-d Swings is a light rhythm farming game built for fun!</p>
-    <a href="about.html" class="about-link">About &amp; FAQ</a>
-  </div>
-  <div class="menu-section leaderboard-container">
-    <h3 class="section-title section-title-green">&#x1F3C6; LEADERBOARD</h3>
-    <a href="leaderboard.html" class="about-link">View Leaderboard</a>
   </div>
 
 


### PR DESCRIPTION
## Summary
- reorder side menu sections with leaderboard first

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6869643abff483319197139db1d7544b