### PR TITLE
Fix syntax error in saveLoad.js

### DIFF
--- a/saveLoad.js
+++ b/saveLoad.js
@@ -256,7 +256,6 @@ function performResetGameData() {
         // Restart the game
         initializeGame();
         showToast('Game reset! Starting fresh.', 'success');
-    }
 }
 
 // Update leaderboard stored in localStorage with latest save info


### PR DESCRIPTION
## Summary
- remove extra closing brace in `performResetGameData`

## Testing
- `node --check saveLoad.js`


------
https://chatgpt.com/codex/tasks/task_e_6869669d63bc8331b1901b901ac897ae