### PR TITLE
Implement username validation

### DIFF
--- a/api/save.php
+++ b/api/save.php
@@ -12,6 +12,26 @@ if (!isset($data['playerID'])) {
     echo json_encode(['error' => 'Missing playerID']);
     exit;
 }
+$banned = ['badword','curse','darn','poop'];
+if (!isset($data['username']) || trim($data['username']) === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing username']);
+    exit;
+}
+$name = preg_replace('/[^a-zA-Z0-9]/', '', $data['username']);
+if (strlen($name) < 3) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Username too short']);
+    exit;
+}
+foreach ($banned as $bw) {
+    if (stripos($name, $bw) !== false) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Inappropriate username']);
+        exit;
+    }
+}
+$data['username'] = $name;
 $id = preg_replace('/[^a-zA-Z0-9_\-]/', '', $data['playerID']);
 $file = __DIR__ . '/../data/saves/' . $id . '.json';
 if (!file_exists(dirname($file))) {

--- a/scripts.js
+++ b/scripts.js
@@ -69,6 +69,13 @@ async function loadGameData() {
     }
 }
 
+const BANNED_WORDS = ['badword', 'curse', 'darn', 'poop'];
+
+function containsBadWord(name) {
+    const lowered = name.toLowerCase();
+    return BANNED_WORDS.some(w => lowered.includes(w));
+}
+
 let gameState = {
     coins: 100,
     milk: 0,
@@ -916,8 +923,20 @@ function updateUsername() {
     const input = document.getElementById('usernameInput');
     if (!input) return;
     const name = input.value.trim();
-    if (!name || !/^[A-Za-z0-9]+$/.test(name)) {
+    if (!name) {
+        showToast('Username is required.', 'error');
+        return;
+    }
+    if (name.length < 3) {
+        showToast('Name must be at least 3 characters.', 'error');
+        return;
+    }
+    if (!/^[A-Za-z0-9]+$/.test(name)) {
         showToast('Name must contain only letters and numbers.', 'error');
+        return;
+    }
+    if (containsBadWord(name)) {
+        showToast('Please choose a different name.', 'error');
         return;
     }
     gameState.username = name;


### PR DESCRIPTION
## Summary
- add banned word list and helper function
- enforce minimum length and check for bad words when picking username
- require and validate username server-side

## Testing
- `php -l api/save.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6869d7a11d9c8331a25cbc10df7a817d