### PR TITLE
Fix leaderboard placeholders

### DIFF
--- a/data/leaderboard.json
+++ b/data/leaderboard.json
@@ -1,8 +1,3 @@
 {
-  "players": [
-    { "name": "Farmer Joe", "xp": 1500, "days": 12 },
-    { "name": "Farmer Jane", "xp": 2100, "days": 15 },
-    { "name": "Cowboy Carl", "xp": 750, "days": 8 },
-    { "name": "Rancher Rick", "xp": 3200, "days": 22 }
-  ]
+  "players": []
 }


### PR DESCRIPTION
## Summary
- remove example players from the leaderboard data

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6869dae6e4b08331abf66747708f8658